### PR TITLE
fix: install libarchive in CI (hotfix/0.5.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install libarchive (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libarchive-dev
+
+      - name: Install libarchive (macOS)
+        if: runner.os == 'macOS'
+        run: brew install libarchive
+
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.1] - 2026-04-03
+
+### Fixed
+- CI release builds now install `libarchive` on Linux and macOS before compiling, fixing failed binary builds for v0.5.0
+
 ## [0.5.0] - 2026-04-02
 
 ### Added

--- a/rewind-cli/Cargo.toml
+++ b/rewind-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewind-cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [[bin]]

--- a/rewind-core/Cargo.toml
+++ b/rewind-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewind-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Installs `libarchive-dev` on Linux and `libarchive` via Homebrew on macOS before building, fixing the `compress-tools` build failure in the v0.5.0 release CI
- Bumps version to 0.5.1 in both crates

## Test plan
- [ ] PR merges into `main` cleanly
- [ ] Tag `v0.5.1` on `main` triggers a successful release build across all platforms
- [ ] Merge back into `next`