### PR TITLE
chore: merge release/0.6.0 back into next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.0] - 2026-04-03
+
+### Added
+- **Game search / filter** — press `/` on the main screen to fuzzy-search your library by name; `Esc` clears the filter and restores your selection
+- **Multiple Steam account support** — rewind now detects all accounts on the machine; pick your preferred account during first run or change it any time in Settings; launch options are loaded for the correct account automatically
+
 ## [0.5.2] - 2026-04-03
 
 ### Fixed

--- a/rewind-cli/Cargo.toml
+++ b/rewind-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewind-cli"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 [[bin]]

--- a/rewind-core/Cargo.toml
+++ b/rewind-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewind-core"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Back-merge after releasing 0.6.0 into `main`.

Brings version bumps and changelog entry back into `next`.

## Merge order

Merge the `main` PR (#44) first, then merge this one.