### PR TITLE
release: 0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
 
       - name: Install libarchive (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y libarchive-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-dev
 
       - name: Install libarchive (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Install libarchive (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y libarchive-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-dev
 
       - name: Install libarchive (macOS)
         if: runner.os == 'macOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.7.0] - 2026-04-05
+
+### Added
+- **Content-addressed cache deduplication** — identical files shared across cached versions are stored only once on disk; re-downloading a file that already exists in another version's cache is skipped automatically
+- **Version labels** — attach a short label (e.g. "pre-nerf", "1.04") to any cached manifest ID; press `E` in the version picker to edit, `Enter` to save, `Esc` to cancel; labels persist in `~/.local/share/rewind/manifests.toml`
+
 ## [0.6.0] - 2026-04-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ If you skip this step, `rewind` will still work but falls back to read-only file
 |---------|---------------------------------|
 | `↑` / `↓` | Select version                |
 | `Enter` | Switch to selected version      |
+| `E`     | Label selected version          |
 | `Esc`   | Cancel                          |
 
 ### Settings

--- a/docs/superpowers/plans/2026-04-05-deduplication.md
+++ b/docs/superpowers/plans/2026-04-05-deduplication.md
@@ -1,0 +1,1195 @@
+# Content-Addressed Cache Deduplication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Avoid downloading files already in cache by checking SHA1 before download, and store all cached game files once in a content-addressed object store.
+
+**Architecture:** DepotDownloader's `-manifest-only` flag produces a manifest txt with per-file SHA1s. Before each download, rewind checks which files are already in `cache/<app_id>/<depot_id>/.objects/<sha1>` and downloads only the missing ones. After download, new files are moved into `.objects/` and manifest dirs hold only symlinks.
+
+**Tech Stack:** Rust, `walkdir`, `tempfile` (tests), `tokio::process::Command`
+
+---
+
+## File Structure
+
+- **Modify:** `rewind-core/src/cache.rs` — add `ManifestEntry`, `parse_manifest_txt`, `missing_entries`, `intern_object`, `link_object`; fix `list_cached_manifests` and `repoint_symlinks`
+- **Modify:** `rewind-core/src/depot.rs` — add `run_manifest_only`, `build_filelist_args`; update `DepotProgress::ReadyToDownload`; update `run_depot_downloader` signature
+- **Modify:** `rewind-cli/src/main.rs` — update `start_download` spawn, `ReadyToDownload` handler, `finalize_downgrade_with_steps`
+
+---
+
+### Task 1: `ManifestEntry` and `parse_manifest_txt`
+
+**Files:**
+- Modify: `rewind-core/src/cache.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add at the bottom of the `#[cfg(test)]` block in `rewind-core/src/cache.rs`:
+
+```rust
+#[test]
+fn parse_manifest_txt_parses_entries() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("manifest.txt");
+    fs::write(&path,
+        "Content Manifest for Depot 3321461\n\
+         \n\
+         Manifest ID / date     : 123 / 01/01/2024 00:00:00\n\
+         Total number of files  : 2\n\
+         Total number of chunks : 5\n\
+         Total bytes on disk    : 1000\n\
+         Total bytes compressed : 800\n\
+         \n\
+         \n\
+                   Size Chunks File SHA                                 Flags Name\n\
+                100      1 aabbccdd00112233445566778899001122334455     0 dir/file.pak\n\
+                200      2 ffeeddccbbaa99887766554433221100ffeeddcc     0 other.bin\n"
+    ).unwrap();
+
+    let entries = parse_manifest_txt(&path).unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].name, "dir/file.pak");
+    assert_eq!(entries[0].sha1, "aabbccdd00112233445566778899001122334455");
+    assert_eq!(entries[0].size_bytes, 100);
+    assert_eq!(entries[1].name, "other.bin");
+    assert_eq!(entries[1].sha1, "ffeeddccbbaa99887766554433221100ffeeddcc");
+    assert_eq!(entries[1].size_bytes, 200);
+}
+
+#[test]
+fn parse_manifest_txt_empty_file_returns_empty() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("manifest.txt");
+    fs::write(&path, "").unwrap();
+    let entries = parse_manifest_txt(&path).unwrap();
+    assert!(entries.is_empty());
+}
+
+#[test]
+fn parse_manifest_txt_header_only_returns_empty() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("manifest.txt");
+    fs::write(&path, "Content Manifest for Depot 123\n\nManifest ID: 456\n").unwrap();
+    let entries = parse_manifest_txt(&path).unwrap();
+    assert!(entries.is_empty());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test -p rewind-core parse_manifest_txt
+```
+
+Expected: FAIL with "cannot find function `parse_manifest_txt`"
+
+- [ ] **Step 3: Add `ManifestEntry` and `parse_manifest_txt` to `cache.rs`**
+
+Add before the `#[cfg(test)]` block:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ManifestEntry {
+    pub name: String,
+    pub sha1: String,
+    pub size_bytes: u64,
+}
+
+/// Parse a DepotDownloader manifest txt file (produced by `-manifest-only`) into entries.
+/// Skips the header block. Data rows are whitespace-split: [size, chunks, sha1, flags, name]
+pub fn parse_manifest_txt(path: &Path) -> Result<Vec<ManifestEntry>, CacheError> {
+    let content = std::fs::read_to_string(path)?;
+    let mut entries = Vec::new();
+    let mut in_data = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Size") && trimmed.contains("Chunks") && trimmed.contains("File SHA") {
+            in_data = true;
+            continue;
+        }
+        if !in_data || trimmed.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+        if parts.len() < 5 {
+            continue;
+        }
+        let size_bytes: u64 = parts[0].parse().unwrap_or(0);
+        let sha1 = parts[2].to_string();
+        let name = parts[4..].join(" ");
+        entries.push(ManifestEntry { name, sha1, size_bytes });
+    }
+
+    Ok(entries)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cargo test -p rewind-core parse_manifest_txt
+```
+
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rewind-core/src/cache.rs
+git commit -m "feat(core): add ManifestEntry and parse_manifest_txt"
+```
+
+---
+
+### Task 2: `missing_entries`
+
+**Files:**
+- Modify: `rewind-core/src/cache.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` block:
+
+```rust
+#[test]
+fn missing_entries_all_missing() {
+    let tmp = TempDir::new().unwrap();
+    let entries = vec![
+        ManifestEntry { name: "a.pak".into(), sha1: "aaaa".into(), size_bytes: 10 },
+        ManifestEntry { name: "b.pak".into(), sha1: "bbbb".into(), size_bytes: 20 },
+    ];
+    let missing = missing_entries(tmp.path(), &entries);
+    assert_eq!(missing.len(), 2);
+}
+
+#[test]
+fn missing_entries_all_present() {
+    let tmp = TempDir::new().unwrap();
+    let objects = tmp.path().join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("aaaa"), b"content a").unwrap();
+    fs::write(objects.join("bbbb"), b"content b").unwrap();
+    let entries = vec![
+        ManifestEntry { name: "a.pak".into(), sha1: "aaaa".into(), size_bytes: 10 },
+        ManifestEntry { name: "b.pak".into(), sha1: "bbbb".into(), size_bytes: 20 },
+    ];
+    let missing = missing_entries(tmp.path(), &entries);
+    assert!(missing.is_empty());
+}
+
+#[test]
+fn missing_entries_mixed() {
+    let tmp = TempDir::new().unwrap();
+    let objects = tmp.path().join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("aaaa"), b"content a").unwrap();
+    let entries = vec![
+        ManifestEntry { name: "a.pak".into(), sha1: "aaaa".into(), size_bytes: 10 },
+        ManifestEntry { name: "b.pak".into(), sha1: "bbbb".into(), size_bytes: 20 },
+    ];
+    let missing = missing_entries(tmp.path(), &entries);
+    assert_eq!(missing.len(), 1);
+    assert_eq!(missing[0].sha1, "bbbb");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test -p rewind-core missing_entries
+```
+
+Expected: FAIL with "cannot find function `missing_entries`"
+
+- [ ] **Step 3: Add `missing_entries` to `cache.rs`**
+
+Add after `parse_manifest_txt`:
+
+```rust
+/// Returns entries whose SHA1 is not present in `depot_dir/.objects/<sha1>`.
+pub fn missing_entries<'a>(
+    depot_dir: &Path,
+    entries: &'a [ManifestEntry],
+) -> Vec<&'a ManifestEntry> {
+    let objects_dir = depot_dir.join(".objects");
+    entries
+        .iter()
+        .filter(|e| !objects_dir.join(&e.sha1).exists())
+        .collect()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cargo test -p rewind-core missing_entries
+```
+
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rewind-core/src/cache.rs
+git commit -m "feat(core): add missing_entries"
+```
+
+---
+
+### Task 3: `intern_object`
+
+**Files:**
+- Modify: `rewind-core/src/cache.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` block:
+
+```rust
+#[test]
+fn intern_object_moves_file_to_objects() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("file.pak");
+    fs::write(&src, b"game content").unwrap();
+    let depot_dir = tmp.path().join("depot");
+
+    let result = intern_object(&depot_dir, &src, "abc123").unwrap();
+
+    assert!(!src.exists());
+    assert_eq!(result, depot_dir.join(".objects/abc123"));
+    assert_eq!(fs::read(&result).unwrap(), b"game content");
+}
+
+#[test]
+fn intern_object_idempotent_when_object_exists() {
+    let tmp = TempDir::new().unwrap();
+    let objects = tmp.path().join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("abc123"), b"existing").unwrap();
+
+    let src = tmp.path().join("dup.pak");
+    fs::write(&src, b"duplicate content").unwrap();
+
+    let result = intern_object(tmp.path(), &src, "abc123").unwrap();
+
+    assert!(!src.exists());
+    assert_eq!(fs::read(&result).unwrap(), b"existing");
+}
+
+#[test]
+fn intern_object_returns_correct_path() {
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("x.pak");
+    fs::write(&src, b"x").unwrap();
+
+    let path = intern_object(tmp.path(), &src, "deadbeef").unwrap();
+    assert_eq!(path, tmp.path().join(".objects/deadbeef"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test -p rewind-core intern_object
+```
+
+Expected: FAIL with "cannot find function `intern_object`"
+
+- [ ] **Step 3: Add `intern_object` to `cache.rs`**
+
+Add after `missing_entries`:
+
+```rust
+/// Move `src` into `depot_dir/.objects/<sha1>`.
+/// If the object already exists, the source file is removed (discard the duplicate).
+/// Returns the object path.
+pub fn intern_object(depot_dir: &Path, src: &Path, sha1: &str) -> Result<PathBuf, CacheError> {
+    let objects_dir = depot_dir.join(".objects");
+    std::fs::create_dir_all(&objects_dir)?;
+    let dest = objects_dir.join(sha1);
+    if dest.exists() {
+        std::fs::remove_file(src)?;
+    } else {
+        std::fs::rename(src, &dest)?;
+    }
+    Ok(dest)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cargo test -p rewind-core intern_object
+```
+
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rewind-core/src/cache.rs
+git commit -m "feat(core): add intern_object"
+```
+
+---
+
+### Task 4: `link_object`
+
+**Files:**
+- Modify: `rewind-core/src/cache.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` block:
+
+```rust
+#[test]
+fn link_object_creates_readable_symlink() {
+    let tmp = TempDir::new().unwrap();
+    let objects = tmp.path().join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("abc123"), b"game content").unwrap();
+
+    let manifest_dir = tmp.path().join("manifest_aaa");
+    fs::create_dir_all(&manifest_dir).unwrap();
+
+    link_object(tmp.path(), "abc123", &manifest_dir, "file.pak").unwrap();
+
+    let link = manifest_dir.join("file.pak");
+    #[cfg(unix)]
+    assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+    assert_eq!(fs::read(&link).unwrap(), b"game content");
+}
+
+#[test]
+fn link_object_creates_subdirectories() {
+    let tmp = TempDir::new().unwrap();
+    let objects = tmp.path().join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("deadbeef"), b"chunk data").unwrap();
+
+    let manifest_dir = tmp.path().join("manifest_bbb");
+    fs::create_dir_all(&manifest_dir).unwrap();
+
+    link_object(tmp.path(), "deadbeef", &manifest_dir, "0000/0.paz").unwrap();
+
+    let link = manifest_dir.join("0000/0.paz");
+    assert!(link.exists());
+    assert_eq!(fs::read(&link).unwrap(), b"chunk data");
+}
+
+#[test]
+fn link_object_overwrites_existing_symlink() {
+    let tmp = TempDir::new().unwrap();
+    let objects = tmp.path().join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("v1hash"), b"v1 content").unwrap();
+    fs::write(objects.join("v2hash"), b"v2 content").unwrap();
+
+    let manifest_dir = tmp.path().join("manifest");
+    fs::create_dir_all(&manifest_dir).unwrap();
+
+    link_object(tmp.path(), "v1hash", &manifest_dir, "file.pak").unwrap();
+    link_object(tmp.path(), "v2hash", &manifest_dir, "file.pak").unwrap();
+
+    assert_eq!(fs::read(manifest_dir.join("file.pak")).unwrap(), b"v2 content");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test -p rewind-core link_object
+```
+
+Expected: FAIL with "cannot find function `link_object`"
+
+- [ ] **Step 3: Add `link_object` to `cache.rs`**
+
+Add after `intern_object`:
+
+```rust
+/// Create a symlink at `manifest_dir/<name>` pointing to the absolute path of
+/// `depot_dir/.objects/<sha1>`. Creates parent directories as needed.
+/// Overwrites an existing symlink at the same path.
+pub fn link_object(
+    depot_dir: &Path,
+    sha1: &str,
+    manifest_dir: &Path,
+    name: &str,
+) -> Result<(), CacheError> {
+    let object_path = depot_dir.join(".objects").join(sha1);
+    let target_abs = std::fs::canonicalize(&object_path)?;
+    let link_path = manifest_dir.join(name);
+
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if link_path.exists() || is_symlink(&link_path) {
+        remove_file_or_symlink(&link_path)?;
+    }
+    create_symlink(&target_abs, &link_path)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+cargo test -p rewind-core link_object
+```
+
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rewind-core/src/cache.rs
+git commit -m "feat(core): add link_object"
+```
+
+---
+
+### Task 5: Fix `list_cached_manifests` and `repoint_symlinks`
+
+**Files:**
+- Modify: `rewind-core/src/cache.rs`
+
+`list_cached_manifests` must exclude `.objects` (which is now a subdirectory of the depot dir).  
+`repoint_symlinks` must follow symlinks so it works when manifest dirs contain symlinks to `.objects/`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` block:
+
+```rust
+#[test]
+fn list_cached_manifests_excludes_objects_dir() {
+    let tmp = TempDir::new().unwrap();
+    let cache_root = tmp.path();
+    let dir1 = manifest_cache_dir(cache_root, 1234, 5678, "v1");
+    fs::create_dir_all(&dir1).unwrap();
+    let objects = cache_root.join("1234/5678/.objects");
+    fs::create_dir_all(&objects).unwrap();
+
+    let manifests = list_cached_manifests(cache_root, 1234, 5678);
+    assert_eq!(manifests, vec!["v1".to_string()]);
+    assert!(!manifests.contains(&".objects".to_string()));
+}
+
+#[test]
+fn repoint_symlinks_follows_symlinks_into_objects() {
+    let tmp = TempDir::new().unwrap();
+    // Set up object store
+    let depot_dir = tmp.path().join("cache/1/2");
+    let objects = depot_dir.join(".objects");
+    fs::create_dir_all(&objects).unwrap();
+    fs::write(objects.join("sha_v2"), b"v2 content").unwrap();
+
+    // Manifest dir where file is a symlink to .objects
+    let manifest_dir = depot_dir.join("v2");
+    fs::create_dir_all(&manifest_dir).unwrap();
+    let obj_abs = fs::canonicalize(objects.join("sha_v2")).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(&obj_abs, manifest_dir.join("main.pak")).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_file(&obj_abs, manifest_dir.join("main.pak")).unwrap();
+
+    // Game dir with an old symlink
+    let game_dir = tmp.path().join("game");
+    fs::create_dir_all(&game_dir).unwrap();
+    let old_obj = objects.parent().unwrap().join(".objects/sha_v1");
+    // (no v1 object needed — just create the game dir file as a regular file)
+    fs::write(game_dir.join("main.pak"), b"old content").unwrap();
+
+    repoint_symlinks(&game_dir, &manifest_dir).unwrap();
+
+    assert_eq!(fs::read(game_dir.join("main.pak")).unwrap(), b"v2 content");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test -p rewind-core list_cached_manifests_excludes_objects_dir repoint_symlinks_follows_symlinks_into_objects
+```
+
+Expected: `list_cached_manifests_excludes_objects_dir` fails (returns `.objects`); `repoint_symlinks_follows_symlinks_into_objects` fails (no files found via symlinks)
+
+- [ ] **Step 3: Fix `list_cached_manifests`**
+
+In `list_cached_manifests`, add a filter to exclude `.objects`. Find this block:
+
+```rust
+            let mut manifests: Vec<String> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .filter_map(|e| e.file_name().into_string().ok())
+                .collect();
+```
+
+Replace with:
+
+```rust
+            let mut manifests: Vec<String> = entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .filter_map(|e| e.file_name().into_string().ok())
+                .filter(|name| name != ".objects")
+                .collect();
+```
+
+- [ ] **Step 4: Fix `repoint_symlinks`**
+
+In `repoint_symlinks`, add `.follow_links(true)` to the WalkDir call. Find:
+
+```rust
+    for entry in WalkDir::new(new_cache_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+```
+
+Replace with:
+
+```rust
+    for entry in WalkDir::new(new_cache_dir)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+cargo test -p rewind-core
+```
+
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rewind-core/src/cache.rs
+git commit -m "fix(core): exclude .objects from manifest list; repoint_symlinks follows links"
+```
+
+---
+
+### Task 6: Depot functions — `run_manifest_only`, `build_filelist_args`, updated `run_depot_downloader`
+
+**Files:**
+- Modify: `rewind-core/src/depot.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)]` block in `depot.rs`:
+
+```rust
+#[test]
+fn build_filelist_args_includes_filelist_flag() {
+    let args = build_filelist_args(570, 571, "abc123", "user", "/tmp/out", "/tmp/list.txt");
+    let s: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    assert!(s.contains(&"-filelist"));
+    let idx = s.iter().position(|&x| x == "-filelist").unwrap();
+    assert_eq!(s[idx + 1], "/tmp/list.txt");
+    // Standard args still present
+    assert!(s.contains(&"-app"));
+    assert!(s.contains(&"-manifest"));
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```
+cargo test -p rewind-core build_filelist_args
+```
+
+Expected: FAIL with "cannot find function `build_filelist_args`"
+
+- [ ] **Step 3: Add `build_filelist_args` to `depot.rs`**
+
+Add after `build_args`:
+
+```rust
+/// Build args for a targeted download using a filelist.
+/// Used when only a subset of manifest files need to be downloaded (deduplication).
+pub fn build_filelist_args(
+    app_id: u32,
+    depot_id: u32,
+    manifest_id: &str,
+    username: &str,
+    output_dir: &str,
+    filelist_path: &str,
+) -> Vec<String> {
+    let mut args = build_args(app_id, depot_id, manifest_id, username, output_dir);
+    args.push("-filelist".into());
+    args.push(filelist_path.into());
+    args
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```
+cargo test -p rewind-core build_filelist_args
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Add `run_manifest_only` to `depot.rs`**
+
+Add after `run_depot_downloader_interactive`. This function runs DepotDownloader with `-manifest-only`, producing `manifest_<depot_id>_<manifest_id>.txt` in `cache_dir`. No interactive I/O needed.
+
+```rust
+/// Run DepotDownloader with `-manifest-only` to produce a human-readable manifest file.
+/// No game files are downloaded. The manifest txt is written to `cache_dir`.
+pub async fn run_manifest_only(
+    binary: &Path,
+    app_id: u32,
+    depot_id: u32,
+    manifest_id: &str,
+    username: &str,
+    cache_dir: &Path,
+) -> Result<(), DepotError> {
+    std::fs::create_dir_all(cache_dir)?;
+    let mut args = build_args(
+        app_id,
+        depot_id,
+        manifest_id,
+        username,
+        cache_dir.to_string_lossy().as_ref(),
+    );
+    args.push("-manifest-only".into());
+
+    let mut cmd = Command::new(binary);
+    cmd.args(&args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    #[cfg(unix)]
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+
+    let status = cmd.spawn()?.wait().await?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(DepotError::ExitFailure(status.code().unwrap_or(-1)))
+    }
+}
+```
+
+- [ ] **Step 6: Update `DepotProgress::ReadyToDownload` to carry the filelist path**
+
+Find:
+
+```rust
+    /// DepotDownloader binary is ready at this path; interactive download can start.
+    ReadyToDownload { binary: std::path::PathBuf },
+```
+
+Replace with:
+
+```rust
+    /// DepotDownloader binary is ready; interactive download can start.
+    /// `filelist_path` is Some when only missing files need downloading (deduplication).
+    /// If None, all files are already cached and the download should be skipped.
+    ReadyToDownload { binary: std::path::PathBuf, filelist_path: Option<std::path::PathBuf> },
+```
+
+- [ ] **Step 7: Update `run_depot_downloader` to accept an optional filelist path**
+
+Find the function signature:
+
+```rust
+pub async fn run_depot_downloader(
+    binary: &Path,
+    app_id: u32,
+    depot_id: u32,
+    manifest_id: &str,
+    username: &str,
+    cache_dir: &Path,
+    tx: mpsc::Sender<DepotProgress>,
+) -> Result<(tokio::process::ChildStdin, mpsc::Sender<()>), DepotError> {
+    std::fs::create_dir_all(cache_dir)?;
+
+    let args = build_args(
+        app_id,
+        depot_id,
+        manifest_id,
+        username,
+        cache_dir.to_string_lossy().as_ref(),
+    );
+```
+
+Replace with:
+
+```rust
+pub async fn run_depot_downloader(
+    binary: &Path,
+    app_id: u32,
+    depot_id: u32,
+    manifest_id: &str,
+    username: &str,
+    cache_dir: &Path,
+    filelist_path: Option<&Path>,
+    tx: mpsc::Sender<DepotProgress>,
+) -> Result<(tokio::process::ChildStdin, mpsc::Sender<()>), DepotError> {
+    std::fs::create_dir_all(cache_dir)?;
+
+    let args = match filelist_path {
+        Some(fp) => build_filelist_args(
+            app_id,
+            depot_id,
+            manifest_id,
+            username,
+            cache_dir.to_string_lossy().as_ref(),
+            fp.to_string_lossy().as_ref(),
+        ),
+        None => build_args(
+            app_id,
+            depot_id,
+            manifest_id,
+            username,
+            cache_dir.to_string_lossy().as_ref(),
+        ),
+    };
+```
+
+- [ ] **Step 8: Run all tests**
+
+```
+cargo test -p rewind-core
+```
+
+Expected: all tests pass. (The CLI will fail to compile until Task 7 — that's fine.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add rewind-core/src/depot.rs
+git commit -m "feat(core): add run_manifest_only, build_filelist_args; update ReadyToDownload and run_depot_downloader"
+```
+
+---
+
+### Task 7: Wire up two-phase download flow in `main.rs`
+
+**Files:**
+- Modify: `rewind-cli/src/main.rs`
+
+This task has three parts: (A) update the tokio spawn to run manifest-only and compute the filelist, (B) update the `ReadyToDownload` handler, (C) replace `apply_downloaded` in `finalize_downgrade_with_steps`.
+
+- [ ] **Step 1: Fix compile errors from `ReadyToDownload` variant change**
+
+`ReadyToDownload` now has `filelist_path`. Find the match arm (around line 140):
+
+```rust
+                rewind_core::depot::DepotProgress::ReadyToDownload { binary } => {
+```
+
+Replace with (temporary — full rewrite follows in Step 3):
+
+```rust
+                rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path } => {
+```
+
+Also find the send in `start_download` (around line 1043):
+
+```rust
+        let _ = tx2
+            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary })
+            .await;
+```
+
+Replace with:
+
+```rust
+        let _ = tx2
+            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path: None })
+            .await;
+```
+
+Also fix the `run_depot_downloader` call (it now requires `filelist_path`). Find:
+
+```rust
+                        match rewind_core::depot::run_depot_downloader(
+                            &binary,
+                            dl.app_id,
+                            dl.depot_id,
+                            &dl.manifest_id,
+                            &dl.username,
+                            &dl.cache_dir,
+                            tx_d,
+                        )
+```
+
+Replace with:
+
+```rust
+                        match rewind_core::depot::run_depot_downloader(
+                            &binary,
+                            dl.app_id,
+                            dl.depot_id,
+                            &dl.manifest_id,
+                            &dl.username,
+                            &dl.cache_dir,
+                            filelist_path.as_deref(),
+                            tx_d,
+                        )
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```
+cargo check
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Update `start_download` spawn to run manifest-only and compute the filelist**
+
+In `start_download`, clone the download parameters before the spawn. Find (around line 989):
+
+```rust
+    app.pending_download = Some(PendingDownload {
+        app_id: game.app_id,
+        depot_id: game.depot_id,
+        manifest_id,
+        username: username.clone(),
+        cache_dir: cache_dir.clone(),
+        game_name: game.name.clone(),
+        game_install_path: game.install_path.clone(),
+        current_manifest_id: game.manifest_id.clone(),
+        acf_path: game.acf_path.clone(),
+    });
+
+    let tx2 = tx.clone();
+    tokio::spawn(async move {
+```
+
+Replace with:
+
+```rust
+    let dl_app_id = game.app_id;
+    let dl_depot_id = game.depot_id;
+    let dl_manifest_id = manifest_id.clone();
+    let dl_username = username.clone();
+    let dl_cache_dir = cache_dir.clone();
+
+    app.pending_download = Some(PendingDownload {
+        app_id: game.app_id,
+        depot_id: game.depot_id,
+        manifest_id,
+        username: username.clone(),
+        cache_dir: cache_dir.clone(),
+        game_name: game.name.clone(),
+        game_install_path: game.install_path.clone(),
+        current_manifest_id: game.manifest_id.clone(),
+        acf_path: game.acf_path.clone(),
+    });
+
+    let tx2 = tx.clone();
+    tokio::spawn(async move {
+```
+
+Now find the end of the spawn (around line 1037), which currently reads:
+
+```rust
+        let _ = tx2
+            .send(rewind_core::depot::DepotProgress::Line(
+                "__STEP_START:DownloadManifest".into(),
+            ))
+            .await;
+        let _ = tx2
+            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path: None })
+            .await;
+    });
+```
+
+Replace with:
+
+```rust
+        let _ = tx2
+            .send(rewind_core::depot::DepotProgress::Line(
+                "__STEP_START:DownloadManifest".into(),
+            ))
+            .await;
+
+        // Phase 1: run manifest-only to get per-file SHA1s without downloading
+        if let Err(e) = rewind_core::depot::run_manifest_only(
+            &binary,
+            dl_app_id,
+            dl_depot_id,
+            &dl_manifest_id,
+            &dl_username,
+            &dl_cache_dir,
+        )
+        .await
+        {
+            let _ = tx2
+                .send(rewind_core::depot::DepotProgress::Error(e.to_string()))
+                .await;
+            return;
+        }
+
+        // Parse manifest txt and determine which files are missing from the object store
+        let manifest_txt = dl_cache_dir
+            .join(format!("manifest_{}_{}.txt", dl_depot_id, dl_manifest_id));
+        let entries = rewind_core::cache::parse_manifest_txt(&manifest_txt).unwrap_or_default();
+        let depot_dir = dl_cache_dir
+            .parent()
+            .expect("manifest cache dir has parent depot dir")
+            .to_path_buf();
+        let missing = rewind_core::cache::missing_entries(&depot_dir, &entries);
+
+        let filelist_path = if missing.is_empty() {
+            None
+        } else {
+            let path = dl_cache_dir.join(".filelist");
+            let content = missing.iter().map(|e| e.name.as_str()).collect::<Vec<_>>().join("\n");
+            if let Err(e) = std::fs::write(&path, content) {
+                let _ = tx2
+                    .send(rewind_core::depot::DepotProgress::Error(e.to_string()))
+                    .await;
+                return;
+            }
+            Some(path)
+        };
+
+        let _ = tx2
+            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path })
+            .await;
+    });
+```
+
+- [ ] **Step 4: Update `ReadyToDownload` handler to skip download when nothing is missing**
+
+Find the `ReadyToDownload` handler (around line 140):
+
+```rust
+                rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path } => {
+                    if let Some(ref dl) = app.pending_download {
+                        let (tx_d, rx_d) = mpsc::channel(64);
+                        app.progress_rx = Some(rx_d);
+
+                        match rewind_core::depot::run_depot_downloader(
+                            &binary,
+                            dl.app_id,
+                            dl.depot_id,
+                            &dl.manifest_id,
+                            &dl.username,
+                            &dl.cache_dir,
+                            filelist_path.as_deref(),
+                            tx_d,
+                        )
+                        .await
+                        {
+                            Ok((stdin, kill_tx)) => {
+                                app.depot_stdin = Some(stdin);
+                                app.depot_kill = Some(kill_tx);
+                            }
+                            Err(e) => {
+                                app.set_step_status(
+                                    &StepKind::DownloadManifest,
+                                    StepStatus::Failed(e.to_string()),
+                                );
+                                app.wizard_state.error =
+                                    Some(format!("Failed to start download: {}", e));
+                                app.wizard_state.is_downloading = false;
+                            }
+                        }
+                    }
+                }
+```
+
+Replace with:
+
+```rust
+                rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path } => {
+                    if filelist_path.is_none() {
+                        // All files already in object store — skip download, finalize directly
+                        app.set_step_status(&StepKind::DownloadManifest, StepStatus::Done);
+                        if let Some(dl) = app.pending_download.take() {
+                            finalize_downgrade_with_steps(&mut app, dl);
+                        }
+                    } else if let Some(ref dl) = app.pending_download {
+                        let (tx_d, rx_d) = mpsc::channel(64);
+                        app.progress_rx = Some(rx_d);
+
+                        match rewind_core::depot::run_depot_downloader(
+                            &binary,
+                            dl.app_id,
+                            dl.depot_id,
+                            &dl.manifest_id,
+                            &dl.username,
+                            &dl.cache_dir,
+                            filelist_path.as_deref(),
+                            tx_d,
+                        )
+                        .await
+                        {
+                            Ok((stdin, kill_tx)) => {
+                                app.depot_stdin = Some(stdin);
+                                app.depot_kill = Some(kill_tx);
+                            }
+                            Err(e) => {
+                                app.set_step_status(
+                                    &StepKind::DownloadManifest,
+                                    StepStatus::Failed(e.to_string()),
+                                );
+                                app.wizard_state.error =
+                                    Some(format!("Failed to start download: {}", e));
+                                app.wizard_state.is_downloading = false;
+                            }
+                        }
+                    }
+                }
+```
+
+- [ ] **Step 5: Replace `apply_downloaded` in `finalize_downgrade_with_steps`**
+
+In `finalize_downgrade_with_steps`, the `current_cache` variable is computed but `apply_downloaded` no longer handles the full flow. We replace that call with:
+1. Parse the manifest txt (already on disk from the manifest-only run)
+2. Backup current game files to `current_cache`
+3. Intern newly downloaded files into `.objects/`
+4. Link all manifest entries in `target_cache`
+5. Repoint game dir symlinks (existing `repoint_symlinks` call)
+
+Find (around line 1224):
+
+```rust
+    let target_cache = rewind_core::cache::manifest_cache_dir(
+        &cache_root,
+        dl.app_id,
+        dl.depot_id,
+        &dl.manifest_id,
+    );
+    let current_cache = rewind_core::cache::manifest_cache_dir(
+        &cache_root,
+        dl.app_id,
+        dl.depot_id,
+        &dl.current_manifest_id,
+    );
+
+    // Step 4: Backup + Step 5: Link
+    app.set_step_status(&StepKind::BackupFiles, StepStatus::InProgress);
+    if let Err(e) =
+        rewind_core::cache::apply_downloaded(&dl.game_install_path, &target_cache, &current_cache)
+    {
+        app.set_step_status(&StepKind::BackupFiles, StepStatus::Failed(e.to_string()));
+        app.wizard_state.error = Some(format!("Failed to apply files: {}", e));
+        app.wizard_state.is_downloading = false;
+        return;
+    }
+    app.set_step_status(&StepKind::BackupFiles, StepStatus::Done);
+    app.set_step_status(&StepKind::LinkFiles, StepStatus::Done);
+```
+
+Replace with:
+
+```rust
+    let target_cache = rewind_core::cache::manifest_cache_dir(
+        &cache_root,
+        dl.app_id,
+        dl.depot_id,
+        &dl.manifest_id,
+    );
+    let current_cache = rewind_core::cache::manifest_cache_dir(
+        &cache_root,
+        dl.app_id,
+        dl.depot_id,
+        &dl.current_manifest_id,
+    );
+    let depot_dir = cache_root
+        .join(dl.app_id.to_string())
+        .join(dl.depot_id.to_string());
+
+    // Parse manifest txt (produced by the manifest-only run in start_download)
+    let manifest_txt = target_cache
+        .join(format!("manifest_{}_{}.txt", dl.depot_id, dl.manifest_id));
+    let entries = rewind_core::cache::parse_manifest_txt(&manifest_txt).unwrap_or_default();
+
+    // Step 4: Backup current game files → current_cache (real file copies)
+    app.set_step_status(&StepKind::BackupFiles, StepStatus::InProgress);
+    if let Err(e) = std::fs::create_dir_all(&current_cache) {
+        app.set_step_status(&StepKind::BackupFiles, StepStatus::Failed(e.to_string()));
+        app.wizard_state.error = Some(format!("Failed to create backup dir: {}", e));
+        app.wizard_state.is_downloading = false;
+        return;
+    }
+    for entry in &entries {
+        let game_file = dl.game_install_path.join(&entry.name);
+        let backup = current_cache.join(&entry.name);
+        if let Some(parent) = backup.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if game_file.exists() {
+            if let Err(e) = std::fs::copy(&game_file, &backup) {
+                app.set_step_status(&StepKind::BackupFiles, StepStatus::Failed(e.to_string()));
+                app.wizard_state.error = Some(format!("Failed to backup file: {}", e));
+                app.wizard_state.is_downloading = false;
+                return;
+            }
+        }
+    }
+    app.set_step_status(&StepKind::BackupFiles, StepStatus::Done);
+
+    // Step 5: Intern newly downloaded files + link all entries in target_cache
+    app.set_step_status(&StepKind::LinkFiles, StepStatus::InProgress);
+    for entry in &entries {
+        let file_in_cache = target_cache.join(&entry.name);
+        // Intern if this is a real file (just downloaded — not already a symlink to .objects)
+        if file_in_cache.exists() && !file_in_cache.symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            if let Err(e) = rewind_core::cache::intern_object(&depot_dir, &file_in_cache, &entry.sha1) {
+                app.set_step_status(&StepKind::LinkFiles, StepStatus::Failed(e.to_string()));
+                app.wizard_state.error = Some(format!("Failed to intern file: {}", e));
+                app.wizard_state.is_downloading = false;
+                return;
+            }
+        }
+        // Create symlink in target_cache pointing to .objects/<sha1>
+        if let Err(e) = rewind_core::cache::link_object(&depot_dir, &entry.sha1, &target_cache, &entry.name) {
+            app.set_step_status(&StepKind::LinkFiles, StepStatus::Failed(e.to_string()));
+            app.wizard_state.error = Some(format!("Failed to link file: {}", e));
+            app.wizard_state.is_downloading = false;
+            return;
+        }
+    }
+
+    // Repoint game dir symlinks to the new manifest's objects
+    if let Err(e) = rewind_core::cache::repoint_symlinks(&dl.game_install_path, &target_cache) {
+        app.set_step_status(&StepKind::LinkFiles, StepStatus::Failed(e.to_string()));
+        app.wizard_state.error = Some(format!("Failed to link game files: {}", e));
+        app.wizard_state.is_downloading = false;
+        return;
+    }
+    app.set_step_status(&StepKind::LinkFiles, StepStatus::Done);
+```
+
+- [ ] **Step 6: Verify it compiles and all tests pass**
+
+```
+cargo check && cargo test
+```
+
+Expected: no compile errors, all tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add rewind-cli/src/main.rs
+git commit -m "feat(cli): wire up two-phase dedup download flow"
+```

--- a/docs/superpowers/plans/2026-04-05-version-labels.md
+++ b/docs/superpowers/plans/2026-04-05-version-labels.md
@@ -1,0 +1,582 @@
+# Version Labels for Cached Manifests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to attach short text labels to cached manifest IDs, stored in a new `manifests.toml` metadata database and displayed in the version picker.
+
+**Architecture:** A new `ManifestDb` type in `rewind-core` owns a `HashMap<String, ManifestMeta>` keyed by manifest ID, persisted to `~/.local/share/rewind/manifests.toml`. `App` holds a `ManifestDb` loaded at startup. The version picker renders labels inline and opens a bottom-bar text editor on `E`.
+
+**Tech Stack:** Rust, serde + toml (already in use), ratatui (already in use)
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `rewind-core/src/manifest_db.rs` | `ManifestDb`, `ManifestMeta`, load/save |
+| Modify | `rewind-core/src/lib.rs` | expose `pub mod manifest_db` |
+| Modify | `rewind-cli/src/app.rs` | add `VersionPickerMode`, `mode` field on `VersionPickerState`, `manifest_db` on `App`, update `App::new` |
+| Modify | `rewind-cli/src/main.rs` | load manifest DB at startup, handle `E` + edit-mode keys |
+| Modify | `rewind-cli/src/ui/version_picker.rs` | render user labels, inline editor bar, updated help text |
+
+---
+
+## Task 1: ManifestDb — core types and TOML I/O
+
+**Files:**
+- Create: `rewind-core/src/manifest_db.rs`
+- Modify: `rewind-core/src/lib.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the bottom of `rewind-core/src/manifest_db.rs` (create the file with just the tests first):
+
+```rust
+use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use crate::config::ConfigError;
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ManifestDb {
+    #[serde(default)]
+    pub manifests: HashMap<String, ManifestMeta>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ManifestMeta {
+    pub label: Option<String>,
+}
+
+impl ManifestDb {
+    pub fn get_label(&self, manifest_id: &str) -> Option<&str> {
+        self.manifests.get(manifest_id)?.label.as_deref()
+    }
+
+    pub fn set_label(&mut self, manifest_id: &str, label: String) {
+        self.manifests
+            .entry(manifest_id.to_string())
+            .or_default()
+            .label = Some(label);
+    }
+
+    pub fn clear_label(&mut self, manifest_id: &str) {
+        if let Some(meta) = self.manifests.get_mut(manifest_id) {
+            meta.label = None;
+        }
+    }
+}
+
+pub fn load_manifest_db() -> Result<ManifestDb, ConfigError> {
+    let path = crate::config::data_dir()?.join("manifests.toml");
+    if !path.exists() {
+        return Ok(ManifestDb::default());
+    }
+    let content = std::fs::read_to_string(&path)?;
+    Ok(toml::from_str(&content)?)
+}
+
+pub fn save_manifest_db(db: &ManifestDb) -> Result<(), ConfigError> {
+    let path = crate::config::data_dir()?.join("manifests.toml");
+    let content = toml::to_string_pretty(db)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_label_returns_none_when_no_entry() {
+        let db = ManifestDb::default();
+        assert!(db.get_label("12345").is_none());
+    }
+
+    #[test]
+    fn set_and_get_label_roundtrip() {
+        let mut db = ManifestDb::default();
+        db.set_label("12345", "pre-nerf".to_string());
+        assert_eq!(db.get_label("12345"), Some("pre-nerf"));
+    }
+
+    #[test]
+    fn clear_label_removes_it() {
+        let mut db = ManifestDb::default();
+        db.set_label("12345", "pre-nerf".to_string());
+        db.clear_label("12345");
+        assert!(db.get_label("12345").is_none());
+    }
+
+    #[test]
+    fn clear_label_on_missing_entry_is_noop() {
+        let mut db = ManifestDb::default();
+        db.clear_label("nonexistent"); // must not panic
+    }
+
+    #[test]
+    fn toml_roundtrip_preserves_labels() {
+        let mut db = ManifestDb::default();
+        db.set_label("7291048563840537431", "pre-nerf".to_string());
+        db.set_label("8812034512345678901", "1.04".to_string());
+
+        let serialized = toml::to_string_pretty(&db).unwrap();
+        let parsed: ManifestDb = toml::from_str(&serialized).unwrap();
+
+        assert_eq!(parsed.get_label("7291048563840537431"), Some("pre-nerf"));
+        assert_eq!(parsed.get_label("8812034512345678901"), Some("1.04"));
+    }
+
+    #[test]
+    fn missing_file_returns_default() {
+        // load_manifest_db uses data_dir() which we can't easily redirect in tests,
+        // but we can verify that an empty TOML string deserializes to default.
+        let db: ManifestDb = toml::from_str("").unwrap();
+        assert!(db.manifests.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Expose the module from lib.rs**
+
+In `rewind-core/src/lib.rs`, add one line:
+
+```rust
+pub mod manifest_db;
+```
+
+(Insert it alphabetically between `pub mod image_cache;` and `pub mod immutability;`.)
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+```bash
+cargo test -p rewind-core manifest_db
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add rewind-core/src/manifest_db.rs rewind-core/src/lib.rs
+git commit -m "feat(core): add ManifestDb type with TOML persistence"
+```
+
+---
+
+## Task 2: Wire ManifestDb into App state
+
+**Files:**
+- Modify: `rewind-cli/src/app.rs`
+- Modify: `rewind-cli/src/main.rs`
+
+- [ ] **Step 1: Add VersionPickerMode to app.rs**
+
+In `rewind-cli/src/app.rs`, add this enum above `VersionPickerState`:
+
+```rust
+#[derive(Debug, Default, PartialEq)]
+pub enum VersionPickerMode {
+    #[default]
+    Browse,
+    EditingLabel { input: String },
+}
+```
+
+- [ ] **Step 2: Add mode field to VersionPickerState**
+
+Replace the existing `VersionPickerState` struct:
+
+```rust
+#[derive(Debug, Default)]
+pub struct VersionPickerState {
+    pub selected_index: usize,
+    /// Set when Steam is detected running on screen open.
+    pub steam_warning: bool,
+    /// Set when an operation is blocked (e.g. Steam still running).
+    pub error: Option<String>,
+    pub mode: VersionPickerMode,
+}
+```
+
+- [ ] **Step 3: Add manifest_db field to App and update App::new**
+
+At the top of `rewind-cli/src/app.rs`, add the import:
+
+```rust
+use rewind_core::manifest_db::ManifestDb;
+```
+
+In the `App` struct, add the field after `games_config`:
+
+```rust
+pub manifest_db: ManifestDb,
+```
+
+Update `App::new` signature and body — replace:
+
+```rust
+pub fn new(config: Config, games_config: GamesConfig) -> Self {
+    let first_run = config.steam_username.is_none() && config.libraries.is_empty();
+    App {
+        screen: if first_run { Screen::FirstRun } else { Screen::Main },
+        config,
+        games_config,
+```
+
+with:
+
+```rust
+pub fn new(config: Config, games_config: GamesConfig, manifest_db: ManifestDb) -> Self {
+    let first_run = config.steam_username.is_none() && config.libraries.is_empty();
+    App {
+        screen: if first_run { Screen::FirstRun } else { Screen::Main },
+        config,
+        games_config,
+        manifest_db,
+```
+
+- [ ] **Step 4: Load manifest_db at startup in main.rs**
+
+In `rewind-cli/src/main.rs`, replace:
+
+```rust
+let cfg = config::load_config().unwrap_or_default();
+let games_cfg = config::load_games().unwrap_or_default();
+run(cfg, games_cfg).await
+```
+
+with:
+
+```rust
+let cfg = config::load_config().unwrap_or_default();
+let games_cfg = config::load_games().unwrap_or_default();
+let manifest_db = rewind_core::manifest_db::load_manifest_db().unwrap_or_default();
+run(cfg, games_cfg, manifest_db).await
+```
+
+And update the `run` function signature — replace:
+
+```rust
+async fn run(
+    cfg: rewind_core::config::Config,
+    games_cfg: rewind_core::config::GamesConfig,
+) -> anyhow::Result<()> {
+    let mut terminal = ratatui::init();
+    let mut app = App::new(cfg, games_cfg);
+```
+
+with:
+
+```rust
+async fn run(
+    cfg: rewind_core::config::Config,
+    games_cfg: rewind_core::config::GamesConfig,
+    manifest_db: rewind_core::manifest_db::ManifestDb,
+) -> anyhow::Result<()> {
+    let mut terminal = ratatui::init();
+    let mut app = App::new(cfg, games_cfg, manifest_db);
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+```bash
+cargo check -p rewind-cli
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rewind-cli/src/app.rs rewind-cli/src/main.rs
+git commit -m "feat(cli): wire ManifestDb into App state"
+```
+
+---
+
+## Task 3: Render labels and inline editor in version picker
+
+**Files:**
+- Modify: `rewind-cli/src/ui/version_picker.rs`
+
+- [ ] **Step 1: Update layout to include editor row**
+
+Replace the existing layout block (the `let layout = Layout::default()...` section) with:
+
+```rust
+let editing = matches!(
+    app.version_picker_state.mode,
+    app::VersionPickerMode::EditingLabel { .. }
+);
+let editor_height: u16 = if editing { 1 } else { 0 };
+
+let layout = Layout::default()
+    .direction(Direction::Vertical)
+    .constraints([
+        Constraint::Length(info_height), // warning / error line
+        Constraint::Min(0),              // version list
+        Constraint::Length(editor_height), // inline label editor
+        Constraint::Length(1),           // help bar
+    ])
+    .split(inner.inner(Margin { horizontal: 1, vertical: 0 }));
+```
+
+- [ ] **Step 2: Update list item rendering to show user labels**
+
+Replace the `let items: Vec<ListItem> = cached.iter().enumerate().map(...)` block with:
+
+```rust
+let items: Vec<ListItem> = cached
+    .iter()
+    .enumerate()
+    .map(|(i, manifest_id)| {
+        let is_active = manifest_id == active;
+        let is_latest = manifest_id == latest;
+
+        let user_label = app.manifest_db.get_label(manifest_id);
+        let display = match user_label {
+            Some(lbl) => format!("{lbl}  {manifest_id}"),
+            None => manifest_id.clone(),
+        };
+
+        let label = match (is_active, is_latest) {
+            (true, true) => format!("● {display} (installed) (latest)"),
+            (true, false) => format!("● {display} (installed)"),
+            (false, true) => format!("  {display} (latest)"),
+            (false, false) => format!("  {display}"),
+        };
+
+        let style = if i == app.version_picker_state.selected_index {
+            theme::selected()
+        } else if is_active {
+            theme::status_success()
+        } else {
+            theme::text()
+        };
+
+        ListItem::new(label).style(style)
+    })
+    .collect();
+```
+
+- [ ] **Step 3: Render inline editor bar**
+
+After the `f.render_widget(list, layout[1]);` line, add:
+
+```rust
+if let app::VersionPickerMode::EditingLabel { input } = &app.version_picker_state.mode {
+    let bar = Paragraph::new(format!(" Label: {}█", input))
+        .style(theme::text());
+    f.render_widget(bar, layout[2]);
+}
+```
+
+- [ ] **Step 4: Update help bar text and index**
+
+Replace the help bar line (it was `layout[2]`, now it's `layout[3]`):
+
+```rust
+let help_text = if editing {
+    " [Enter] confirm   [Esc] cancel "
+} else {
+    " [↑↓] select   [Enter] switch   [E] label   [Esc] cancel "
+};
+let help = Paragraph::new(help_text).style(theme::help_bar());
+f.render_widget(help, layout[3]);
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+```bash
+cargo check -p rewind-cli
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rewind-cli/src/ui/version_picker.rs
+git commit -m "feat(cli): render version labels and inline editor in version picker"
+```
+
+---
+
+## Task 4: Key handling for label editing
+
+**Files:**
+- Modify: `rewind-cli/src/main.rs`
+
+- [ ] **Step 1: Replace handle_version_picker with mode-aware version**
+
+Replace the entire `fn handle_version_picker(app: &mut App, key: KeyCode)` function with:
+
+```rust
+fn handle_version_picker(app: &mut App, key: KeyCode) {
+    // --- Editing mode: intercept all keys ---
+    if matches!(app.version_picker_state.mode, app::VersionPickerMode::EditingLabel { .. }) {
+        match key {
+            KeyCode::Esc => {
+                app.version_picker_state.mode = app::VersionPickerMode::Browse;
+            }
+            KeyCode::Enter => {
+                let input = match &app.version_picker_state.mode {
+                    app::VersionPickerMode::EditingLabel { input } => input.trim().to_string(),
+                    _ => unreachable!(),
+                };
+                let manifest_id = app
+                    .selected_game_entry()
+                    .and_then(|e| {
+                        e.cached_manifest_ids.get(app.version_picker_state.selected_index)
+                    })
+                    .cloned();
+                if let Some(id) = manifest_id {
+                    if input.is_empty() {
+                        app.manifest_db.clear_label(&id);
+                    } else {
+                        app.manifest_db.set_label(&id, input);
+                    }
+                    let _ = rewind_core::manifest_db::save_manifest_db(&app.manifest_db);
+                }
+                app.version_picker_state.mode = app::VersionPickerMode::Browse;
+            }
+            KeyCode::Backspace => {
+                if let app::VersionPickerMode::EditingLabel { input } =
+                    &mut app.version_picker_state.mode
+                {
+                    input.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let app::VersionPickerMode::EditingLabel { input } =
+                    &mut app.version_picker_state.mode
+                {
+                    input.push(c);
+                }
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    // --- Browse mode ---
+    let cached_len = app
+        .selected_game_entry()
+        .map(|e| e.cached_manifest_ids.len())
+        .unwrap_or(0);
+
+    match key {
+        KeyCode::Esc => app.screen = Screen::Main,
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.version_picker_state.selected_index > 0 {
+                app.version_picker_state.selected_index -= 1;
+            }
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.version_picker_state.selected_index + 1 < cached_len {
+                app.version_picker_state.selected_index += 1;
+            }
+        }
+        KeyCode::Char('e') | KeyCode::Char('E') => {
+            let existing = app
+                .selected_game_entry()
+                .and_then(|e| {
+                    e.cached_manifest_ids.get(app.version_picker_state.selected_index)
+                })
+                .and_then(|id| app.manifest_db.get_label(id))
+                .unwrap_or("")
+                .to_string();
+            app.version_picker_state.mode =
+                app::VersionPickerMode::EditingLabel { input: existing };
+        }
+        KeyCode::Enter => {
+            let target_manifest = app
+                .selected_game_entry()
+                .and_then(|e| e.cached_manifest_ids.get(app.version_picker_state.selected_index))
+                .cloned();
+
+            if let Some(manifest_id) = target_manifest {
+                let is_current = app
+                    .selected_game_entry()
+                    .map(|e| e.active_manifest_id == manifest_id)
+                    .unwrap_or(false);
+
+                if is_current {
+                    app.screen = Screen::Main;
+                    return;
+                }
+
+                if rewind_core::steam_guard::is_steam_running() {
+                    app.version_picker_state.error =
+                        Some("Steam is running. Quit Steam before switching versions.".into());
+                    return;
+                }
+
+                let is_latest = app
+                    .selected_game_entry()
+                    .map(|e| e.latest_manifest_id == manifest_id)
+                    .unwrap_or(false);
+
+                let mut steps = vec![
+                    (app::StepKind::RepointSymlinks, app::StepStatus::Pending),
+                    (app::StepKind::PatchAcf, app::StepStatus::Pending),
+                ];
+                if is_latest {
+                    steps.push((app::StepKind::LockAcf, app::StepStatus::Done));
+                } else {
+                    steps.push((app::StepKind::LockAcf, app::StepStatus::Pending));
+                }
+
+                app.switch_overlay_state = app::SwitchOverlayState {
+                    steps,
+                    target_manifest: manifest_id.clone(),
+                    done: false,
+                    lock_skipped: is_latest,
+                };
+                app.screen = Screen::SwitchOverlay;
+
+                switch_to_cached_version(app, manifest_id, is_latest);
+            }
+        }
+        _ => {}
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo check -p rewind-cli
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run all tests**
+
+```bash
+cargo test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+cargo run
+```
+
+- Open the version picker on a game with cached manifests (`V` key)
+- Press `E` — confirm the label bar appears at the bottom
+- Type a label (e.g. `pre-nerf`) — confirm characters appear
+- Press `Enter` — confirm bar closes and the label is shown before the manifest ID
+- Press `E` again — confirm the bar is pre-populated with `pre-nerf`
+- Clear the input and press `Enter` — confirm the label disappears
+- Press `Esc` while editing — confirm bar closes with no change
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rewind-cli/src/main.rs
+git commit -m "feat(cli): handle E key for version label editing"
+```

--- a/docs/superpowers/specs/2026-04-05-deduplication-design.md
+++ b/docs/superpowers/specs/2026-04-05-deduplication-design.md
@@ -1,0 +1,205 @@
+# Content-Addressed Cache Deduplication — Design Spec
+
+**Issue:** [#46](https://github.com/yanekyuk/rewind/issues/46)  
+**Milestone:** 0.7.0 — Cache and manifest management
+
+---
+
+## Problem
+
+When multiple versions are cached for a game, files that are identical across versions are stored multiple times on disk. There is no mechanism to detect or eliminate these duplicates, and no way to avoid re-downloading files that are already cached in a different manifest.
+
+---
+
+## Goals
+
+- Eliminate redundant file storage: identical files across manifest versions are stored once
+- Avoid downloading files already in the cache: pre-check SHA1 against the object store before downloading
+- Keep the existing symlink-based game directory mechanism intact
+
+---
+
+## Non-Goals
+
+- Deletion of cached versions (#34) — handled in 0.8.0 once the object store is in place
+- Disk usage display (#33) — handled in 0.8.0
+- Cross-game or cross-depot deduplication (depot boundaries are the unit of deduplication)
+
+---
+
+## Architecture
+
+### Content-addressed object store
+
+A `.objects/` directory inside each depot's cache dir holds the canonical file content, keyed by Steam's per-file SHA1 hash:
+
+```
+cache/<app_id>/<depot_id>/
+├── .objects/
+│   ├── 8a11847b3e22b2fb909b57787ed94d1bb139bcb2   ← real file
+│   ├── 3e6800918fef5f8880cf601e5b60bff031465e60   ← real file
+│   └── ...
+├── <manifest_id_1>/
+│   ├── 0000/0.pamt   → ../../.objects/8a11847b...   ← symlink
+│   ├── 0000/0.paz    → ../../.objects/3e680091...   ← symlink
+│   └── ...
+└── <manifest_id_2>/
+    ├── 0000/0.pamt   → ../../.objects/8a11847b...   ← same object, no duplicate
+    └── ...
+```
+
+Every file in a manifest directory is a symlink. Real bytes live in `.objects/` exactly once per unique SHA1.
+
+### Why SHA1 (not BLAKE3 or SHA256)
+
+DepotDownloader's `-manifest-only` flag produces a human-readable `manifest_<depot>_<manifest>.txt` with a per-file SHA1. Using Steam's SHA1 directly as the object key means:
+
+- No hashing step required on our side — the hash is known before downloading
+- Object existence check is a single `Path::exists()` call
+- No mismatch between our hash and DepotDownloader's hash
+
+### Manifest txt format
+
+```
+Content Manifest for Depot 3321461
+
+Manifest ID / date     : 3559081655545104676 / 03/22/2026 16:01:45
+Total number of files  : 257
+Total number of chunks : 130874
+Total bytes on disk    : 133352312992
+Total bytes compressed : 100116131120
+
+
+          Size Chunks File SHA                                 Flags Name
+       6740755      7 8a11847b3e22b2fb909b57787ed94d1bb139bcb2     0 0000/0.pamt
+     912261088    896 3e6800918fef5f8880cf601e5b60bff031465e60     0 0000/0.paz
+```
+
+Fields (whitespace-split): `size chunks sha1 flags name`
+
+The header block (lines before the column header) is skipped during parsing.
+
+---
+
+## Core Types (`rewind-core/src/cache.rs`)
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ManifestEntry {
+    pub name: String,       // relative path, e.g. "0000/0.paz"
+    pub sha1: String,       // 40-char lowercase hex
+    pub size_bytes: u64,
+}
+```
+
+---
+
+## Core Functions (`rewind-core/src/cache.rs`)
+
+### `parse_manifest_txt`
+
+```rust
+pub fn parse_manifest_txt(path: &Path) -> Result<Vec<ManifestEntry>, CacheError>
+```
+
+Parses the human-readable manifest txt produced by `-manifest-only`. Skips all header lines (before the data rows). Each data row is whitespace-split: fields are `[size, chunks, sha1, flags, name]`.
+
+### `missing_entries`
+
+```rust
+pub fn missing_entries<'a>(
+    depot_dir: &Path,
+    entries: &'a [ManifestEntry],
+) -> Vec<&'a ManifestEntry>
+```
+
+Returns entries whose SHA1 is not present in `depot_dir/.objects/<sha1>`.
+
+### `intern_object`
+
+```rust
+pub fn intern_object(
+    depot_dir: &Path,
+    src: &Path,
+    sha1: &str,
+) -> Result<PathBuf, CacheError>
+```
+
+Moves `src` into `depot_dir/.objects/<sha1>`. If the object already exists (concurrent or retry scenario), the source file is discarded. Returns the object path.
+
+### `link_object`
+
+```rust
+pub fn link_object(
+    depot_dir: &Path,
+    sha1: &str,
+    manifest_dir: &Path,
+    name: &str,
+) -> Result<(), CacheError>
+```
+
+Creates a symlink at `manifest_dir/<name>` pointing to the absolute path of `depot_dir/.objects/<sha1>`. Creates parent directories as needed. Overwrites an existing symlink at the same path. Absolute paths are used (consistent with the existing `create_symlink` behavior in `cache.rs`) to avoid depth-dependent relative path calculations for files in subdirectories.
+
+---
+
+## Download Flow Changes (`rewind-cli/src/main.rs`)
+
+The existing `apply_downloaded()` call is **replaced** by a two-phase flow:
+
+### Phase 1 — Pre-download
+
+Both phases use the manifest cache dir (`cache/<app_id>/<depot_id>/<manifest_id>/`) as the `-dir` argument to DepotDownloader.
+
+1. Run DepotDownloader with `-manifest-only -dir <manifest_cache_dir>` → produces `manifest_<depot>_<manifest>.txt` in that dir (no game files downloaded)
+2. Parse with `parse_manifest_txt()`
+3. Call `missing_entries()` against the depot's `.objects/`
+4. **If nothing missing:** skip the full download entirely — proceed directly to Phase 2 step 2
+5. **If some missing:** write their paths to a temp filelist, pass `-filelist <path> -dir <manifest_cache_dir>` to the real DepotDownloader invocation
+
+### Phase 2 — Post-download
+
+1. For each file in the filelist (downloaded into `<manifest_cache_dir>`): call `intern_object()` → moves it to `.objects/<sha1>`
+2. For every entry in the manifest: call `link_object()` → creates symlink in manifest cache dir (whether the object was just interned or was already present)
+3. The manifest txt is already saved at `<manifest_cache_dir>/manifest_<depot>_<manifest>.txt` from Phase 1 — no extra copy needed
+
+### Unchanged
+
+- `repoint_symlinks()` — unchanged; operates on manifest dir symlinks, which now point to `.objects/` instead of real files
+- `restore_from_cache()` — unchanged; `std::fs::copy` follows symlinks, so content is correctly restored
+- `cached_manifest_ids` tracking in `games.toml` — unchanged
+
+---
+
+## Testing
+
+All tests in `rewind-core/src/cache.rs` using `tempfile::TempDir`.
+
+### `parse_manifest_txt`
+- Correctly formatted input → correct `ManifestEntry` fields (name, sha1, size)
+- Header lines and blank lines are skipped
+- Empty file → empty vec
+
+### `missing_entries`
+- All entries missing → returns all
+- All entries present in `.objects/` → returns none
+- Mixed → returns only missing ones
+
+### `intern_object`
+- Moves file to `.objects/<sha1>`, original path no longer exists
+- If object already exists, does not error (idempotent)
+- Returns the correct object path
+
+### `link_object`
+- Creates symlink at `manifest_dir/name` pointing to correct object
+- Symlink target is readable (resolves correctly)
+- Overwrites an existing symlink without error
+- Creates intermediate directories for nested paths (e.g. `0000/0.paz`)
+
+### Integration: full download flow simulation
+- All files missing → all entries in filelist, all interned and linked
+- All files present → empty filelist, symlinks created without any download
+- Partial overlap → only missing files in filelist, existing ones linked directly
+
+### Regression
+- `repoint_symlinks` works when manifest dir contains symlinks into `.objects/`
+- `restore_from_cache` correctly copies file content through the symlink chain

--- a/docs/superpowers/specs/2026-04-05-version-labels-design.md
+++ b/docs/superpowers/specs/2026-04-05-version-labels-design.md
@@ -1,0 +1,132 @@
+# Version Labels for Cached Manifests — Design Spec
+
+**Issue:** [#32](https://github.com/yanekyuk/rewind/issues/32)  
+**Milestone:** 0.7.0 — Cache and manifest management
+
+---
+
+## Problem
+
+The version picker and detail panel show raw manifest IDs (e.g. `7291048563840537431`), which are meaningless at a glance. Users maintaining multiple cached versions can't tell them apart without cross-referencing SteamDB.
+
+---
+
+## Goals
+
+- Allow users to attach a short label to any cached manifest (e.g. "pre-nerf", "speedrun patch", "1.04")
+- Display labels alongside manifest IDs in the version picker
+- Persist labels in a way that can grow into a broader manifest metadata database over time
+
+---
+
+## Non-Goals
+
+- Labels do not affect version switching logic
+- No community/shared label import in this iteration
+- No label on `active_manifest_id` or `latest_manifest_id` fields directly (those are in `games.toml`; labels live in the separate DB)
+
+---
+
+## Architecture
+
+### New file: `manifests.toml`
+
+A new file at `~/.local/share/rewind/manifests.toml` serves as a manifest metadata database, keyed globally by manifest ID.
+
+```toml
+[manifests.7291048563840537431]
+label = "pre-nerf"
+
+[manifests.8812034512345678901]
+label = "1.04"
+```
+
+**Why separate from `games.toml`:**
+- Zero migration cost — `games.toml` and its `cached_manifest_ids: Vec<String>` are untouched
+- Manifest IDs are global (a depot manifest doesn't belong to one game entry)
+- Future fields (`size_bytes`, `downloaded_at`, `source`) can be added to `ManifestMeta` without touching game config
+- Enables future seeding from SteamDB data, community CSVs, or download history
+
+### Core types (`rewind-core/src/manifest_db.rs`)
+
+```rust
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ManifestDb {
+    #[serde(default)]
+    pub manifests: HashMap<String, ManifestMeta>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ManifestMeta {
+    pub label: Option<String>,
+    // future: pub size_bytes: Option<u64>,
+    // future: pub downloaded_at: Option<DateTime<Utc>>,
+    // future: pub source: Option<String>,
+}
+```
+
+### Core functions (`rewind-core/src/manifest_db.rs`)
+
+- `load_manifest_db() -> Result<ManifestDb, ConfigError>` — reads `manifests.toml`, returns default if missing
+- `save_manifest_db(db: &ManifestDb) -> Result<(), ConfigError>` — writes `manifests.toml`
+- `ManifestDb::get_label(&self, manifest_id: &str) -> Option<&str>`
+- `ManifestDb::set_label(&mut self, manifest_id: &str, label: String)`
+- `ManifestDb::clear_label(&mut self, manifest_id: &str)`
+
+`ManifestDb` is exposed from `rewind-core`'s public API alongside `GameEntry` and `GamesConfig`.
+
+---
+
+## UI Changes (`rewind-cli`)
+
+### Version picker rendering
+
+When rendering each entry in the cached manifest list, the version picker reads from `AppState.manifest_db` and looks up each manifest ID:
+
+- **With label:** `● pre-nerf  7291048563840537431  (installed)`
+- **Without label:** `●  7291048563840537431  (installed)`
+
+Label is shown first, left-aligned, in a distinct style (e.g. bold or accent color). Manifest ID follows in a dimmed style.
+
+### Inline label editor
+
+Keybinding `E` on a selected manifest opens an inline input bar at the bottom of the version picker screen (same visual register as a vim `:` command line):
+
+```
+Label: [pre-nerf_             ]   Enter to confirm · Esc to cancel
+```
+
+- Pre-populated with the existing label if one exists, empty otherwise
+- `Enter` saves to `ManifestDb` and closes the bar
+- `Esc` cancels with no change
+- Empty input + `Enter` clears the label
+
+### App state
+
+`VersionPickerState` gains a `mode` field to track the inline editing mode:
+
+```rust
+pub enum VersionPickerMode {
+    Browse,
+    EditingLabel { input: String },
+}
+```
+
+`ManifestDb` is loaded into `AppState` at startup (alongside `GamesConfig`) and written on label save.
+
+---
+
+## Data Flow
+
+1. App starts → `load_manifest_db()` → stored in `AppState`
+2. Version picker renders → looks up each manifest ID in `ManifestDb`
+3. User presses `E` → `VersionPickerMode::EditingLabel` with pre-populated input
+4. User confirms → `ManifestDb::set_label(...)` → `save_manifest_db(...)` → mode back to `Browse`
+
+---
+
+## Testing
+
+- Unit tests in `rewind-core`: roundtrip serialize/deserialize of `ManifestDb`, `get_label`/`set_label`/`clear_label` behavior, missing file returns default
+- UI logic: label edit mode transitions (browse → editing → browse), empty input clears label
+- No integration tests needed for this feature (pure metadata, no filesystem side effects beyond the TOML file)

--- a/rewind-cli/Cargo.toml
+++ b/rewind-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewind-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [[bin]]

--- a/rewind-cli/src/app.rs
+++ b/rewind-cli/src/app.rs
@@ -3,6 +3,7 @@ use fuzzy_matcher::FuzzyMatcher;
 use rewind_core::{
     config::{Config, GameEntry, GamesConfig},
     depot::DepotProgress,
+    manifest_db::ManifestDb,
     reshade::ReshadeProgress,
     scanner::{InstalledGame, SteamAccount},
 };
@@ -93,6 +94,13 @@ pub struct SettingsState {
     pub account_index: usize,
 }
 
+#[derive(Debug, Default, PartialEq)]
+pub enum VersionPickerMode {
+    #[default]
+    Browse,
+    EditingLabel { input: String },
+}
+
 #[derive(Debug, Default)]
 pub struct VersionPickerState {
     pub selected_index: usize,
@@ -100,6 +108,7 @@ pub struct VersionPickerState {
     pub steam_warning: bool,
     /// Set when an operation is blocked (e.g. Steam still running).
     pub error: Option<String>,
+    pub mode: VersionPickerMode,
 }
 
 #[derive(Debug, Default)]
@@ -173,6 +182,7 @@ pub struct App {
     pub screen: Screen,
     pub config: Config,
     pub games_config: GamesConfig,
+    pub manifest_db: ManifestDb,
     pub installed_games: Vec<InstalledGame>,
     pub selected_game_index: usize,
     pub wizard_state: DowngradeWizardState,
@@ -205,12 +215,13 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: Config, games_config: GamesConfig) -> Self {
+    pub fn new(config: Config, games_config: GamesConfig, manifest_db: ManifestDb) -> Self {
         let first_run = config.steam_username.is_none() && config.libraries.is_empty();
         App {
             screen: if first_run { Screen::FirstRun } else { Screen::Main },
             config,
             games_config,
+            manifest_db,
             installed_games: Vec::new(),
             selected_game_index: 0,
             wizard_state: DowngradeWizardState::default(),
@@ -293,7 +304,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn make_app(names: &[&str]) -> App {
-        let mut app = App::new(Config::default(), GamesConfig::default());
+        let mut app = App::new(Config::default(), GamesConfig::default(), ManifestDb::default());
         app.installed_games = names
             .iter()
             .enumerate()

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -1298,6 +1298,12 @@ fn finalize_downgrade_with_steps(app: &mut App, dl: PendingDownload) {
     let manifest_txt = target_cache
         .join(format!("manifest_{}_{}.txt", dl.depot_id, dl.manifest_id));
     let entries = rewind_core::cache::parse_manifest_txt(&manifest_txt).unwrap_or_default();
+    if entries.is_empty() {
+        app.set_step_status(&StepKind::BackupFiles, StepStatus::Failed("Manifest file is empty or missing".into()));
+        app.wizard_state.error = Some("Manifest file could not be read — cannot apply downgrade".to_string());
+        app.wizard_state.is_downloading = false;
+        return;
+    }
 
     // Step 4: Backup current game files → current_cache (real file copies)
     app.set_step_status(&StepKind::BackupFiles, StepStatus::InProgress);

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -34,15 +34,17 @@ fn open_settings(app: &mut App) {
 async fn main() -> anyhow::Result<()> {
     let cfg = config::load_config().unwrap_or_default();
     let games_cfg = config::load_games().unwrap_or_default();
-    run(cfg, games_cfg).await
+    let manifest_db = rewind_core::manifest_db::load_manifest_db().unwrap_or_default();
+    run(cfg, games_cfg, manifest_db).await
 }
 
 async fn run(
     cfg: rewind_core::config::Config,
     games_cfg: rewind_core::config::GamesConfig,
+    manifest_db: rewind_core::manifest_db::ManifestDb,
 ) -> anyhow::Result<()> {
     let mut terminal = ratatui::init();
-    let mut app = App::new(cfg, games_cfg);
+    let mut app = App::new(cfg, games_cfg, manifest_db);
 
     // Auto-detect Steam libraries on first run
     if app.config.libraries.is_empty() {
@@ -441,6 +443,7 @@ fn handle_main(app: &mut App, key: KeyCode) {
                     selected_index: 0,
                     steam_warning: steam_running,
                     error: None,
+                    mode: app::VersionPickerMode::Browse,
                 };
                 app.screen = Screen::VersionPicker;
             }

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -137,8 +137,14 @@ async fn run(
                         app.last_depot_output = Some(std::time::Instant::now());
                     }
                 }
-                rewind_core::depot::DepotProgress::ReadyToDownload { binary } => {
-                    if let Some(ref dl) = app.pending_download {
+                rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path } => {
+                    if filelist_path.is_none() {
+                        // All files already in object store — skip download, finalize directly
+                        app.set_step_status(&StepKind::DownloadManifest, StepStatus::Done);
+                        if let Some(dl) = app.pending_download.take() {
+                            finalize_downgrade_with_steps(&mut app, dl);
+                        }
+                    } else if let Some(ref dl) = app.pending_download {
                         let (tx_d, rx_d) = mpsc::channel(64);
                         app.progress_rx = Some(rx_d);
 
@@ -149,6 +155,7 @@ async fn run(
                             &dl.manifest_id,
                             &dl.username,
                             &dl.cache_dir,
+                            filelist_path.as_deref(),
                             tx_d,
                         )
                         .await
@@ -1040,7 +1047,7 @@ fn start_download(app: &mut App) {
             ))
             .await;
         let _ = tx2
-            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary })
+            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path: None })
             .await;
     });
 }

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -1073,7 +1073,17 @@ fn start_download(app: &mut App) {
         // Parse manifest txt and determine which files are missing from the object store
         let manifest_txt = dl_cache_dir
             .join(format!("manifest_{}_{}.txt", dl_depot_id, dl_manifest_id));
-        let entries = rewind_core::cache::parse_manifest_txt(&manifest_txt).unwrap_or_default();
+        let entries = match rewind_core::cache::parse_manifest_txt(&manifest_txt) {
+            Ok(e) => e,
+            Err(e) => {
+                let _ = tx2
+                    .send(rewind_core::depot::DepotProgress::Error(format!(
+                        "Failed to parse manifest: {e}"
+                    )))
+                    .await;
+                return;
+            }
+        };
         let depot_dir = dl_cache_dir
             .parent()
             .expect("manifest cache dir has parent depot dir")

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -629,6 +629,53 @@ fn handle_wizard(app: &mut App, key: KeyCode) {
 }
 
 fn handle_version_picker(app: &mut App, key: KeyCode) {
+    // --- Editing mode: intercept all keys ---
+    if matches!(app.version_picker_state.mode, app::VersionPickerMode::EditingLabel { .. }) {
+        match key {
+            KeyCode::Esc => {
+                app.version_picker_state.mode = app::VersionPickerMode::Browse;
+            }
+            KeyCode::Enter => {
+                let input = match &app.version_picker_state.mode {
+                    app::VersionPickerMode::EditingLabel { input } => input.trim().to_string(),
+                    _ => unreachable!(),
+                };
+                let manifest_id = app
+                    .selected_game_entry()
+                    .and_then(|e| {
+                        e.cached_manifest_ids.get(app.version_picker_state.selected_index)
+                    })
+                    .cloned();
+                if let Some(id) = manifest_id {
+                    if input.is_empty() {
+                        app.manifest_db.clear_label(&id);
+                    } else {
+                        app.manifest_db.set_label(&id, input);
+                    }
+                    let _ = rewind_core::manifest_db::save_manifest_db(&app.manifest_db);
+                }
+                app.version_picker_state.mode = app::VersionPickerMode::Browse;
+            }
+            KeyCode::Backspace => {
+                if let app::VersionPickerMode::EditingLabel { input } =
+                    &mut app.version_picker_state.mode
+                {
+                    input.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if let app::VersionPickerMode::EditingLabel { input } =
+                    &mut app.version_picker_state.mode
+                {
+                    input.push(c);
+                }
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    // --- Browse mode ---
     let cached_len = app
         .selected_game_entry()
         .map(|e| e.cached_manifest_ids.len())
@@ -646,6 +693,18 @@ fn handle_version_picker(app: &mut App, key: KeyCode) {
                 app.version_picker_state.selected_index += 1;
             }
         }
+        KeyCode::Char('e') | KeyCode::Char('E') => {
+            let existing = app
+                .selected_game_entry()
+                .and_then(|e| {
+                    e.cached_manifest_ids.get(app.version_picker_state.selected_index)
+                })
+                .and_then(|id| app.manifest_db.get_label(id))
+                .unwrap_or("")
+                .to_string();
+            app.version_picker_state.mode =
+                app::VersionPickerMode::EditingLabel { input: existing };
+        }
         KeyCode::Enter => {
             let target_manifest = app
                 .selected_game_entry()
@@ -653,7 +712,6 @@ fn handle_version_picker(app: &mut App, key: KeyCode) {
                 .cloned();
 
             if let Some(manifest_id) = target_manifest {
-                // Check if this is the currently installed manifest
                 let is_current = app
                     .selected_game_entry()
                     .map(|e| e.active_manifest_id == manifest_id)
@@ -675,7 +733,6 @@ fn handle_version_picker(app: &mut App, key: KeyCode) {
                     .map(|e| e.latest_manifest_id == manifest_id)
                     .unwrap_or(false);
 
-                // Initialize switch overlay steps
                 let mut steps = vec![
                     (app::StepKind::RepointSymlinks, app::StepStatus::Pending),
                     (app::StepKind::PatchAcf, app::StepStatus::Pending),

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -1290,18 +1290,72 @@ fn finalize_downgrade_with_steps(app: &mut App, dl: PendingDownload) {
         dl.depot_id,
         &dl.current_manifest_id,
     );
+    let depot_dir = cache_root
+        .join(dl.app_id.to_string())
+        .join(dl.depot_id.to_string());
 
-    // Step 4: Backup + Step 5: Link
+    // Parse manifest txt (produced by the manifest-only run in start_download)
+    let manifest_txt = target_cache
+        .join(format!("manifest_{}_{}.txt", dl.depot_id, dl.manifest_id));
+    let entries = rewind_core::cache::parse_manifest_txt(&manifest_txt).unwrap_or_default();
+
+    // Step 4: Backup current game files → current_cache (real file copies)
     app.set_step_status(&StepKind::BackupFiles, StepStatus::InProgress);
-    if let Err(e) =
-        rewind_core::cache::apply_downloaded(&dl.game_install_path, &target_cache, &current_cache)
-    {
+    if let Err(e) = std::fs::create_dir_all(&current_cache) {
         app.set_step_status(&StepKind::BackupFiles, StepStatus::Failed(e.to_string()));
-        app.wizard_state.error = Some(format!("Failed to apply files: {}", e));
+        app.wizard_state.error = Some(format!("Failed to create backup dir: {}", e));
         app.wizard_state.is_downloading = false;
         return;
     }
+    for entry in &entries {
+        let game_file = dl.game_install_path.join(&entry.name);
+        let backup = current_cache.join(&entry.name);
+        if let Some(parent) = backup.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if game_file.exists() {
+            if let Err(e) = std::fs::copy(&game_file, &backup) {
+                app.set_step_status(&StepKind::BackupFiles, StepStatus::Failed(e.to_string()));
+                app.wizard_state.error = Some(format!("Failed to backup file: {}", e));
+                app.wizard_state.is_downloading = false;
+                return;
+            }
+        }
+    }
     app.set_step_status(&StepKind::BackupFiles, StepStatus::Done);
+
+    // Step 5: Intern newly downloaded files + link all entries in target_cache
+    app.set_step_status(&StepKind::LinkFiles, StepStatus::InProgress);
+    for entry in &entries {
+        let file_in_cache = target_cache.join(&entry.name);
+        // Intern if this is a real file (just downloaded — not already a symlink to .objects)
+        if file_in_cache.exists() && !file_in_cache.symlink_metadata()
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+        {
+            if let Err(e) = rewind_core::cache::intern_object(&depot_dir, &file_in_cache, &entry.sha1) {
+                app.set_step_status(&StepKind::LinkFiles, StepStatus::Failed(e.to_string()));
+                app.wizard_state.error = Some(format!("Failed to intern file: {}", e));
+                app.wizard_state.is_downloading = false;
+                return;
+            }
+        }
+        // Create symlink in target_cache pointing to .objects/<sha1>
+        if let Err(e) = rewind_core::cache::link_object(&depot_dir, &entry.sha1, &target_cache, &entry.name) {
+            app.set_step_status(&StepKind::LinkFiles, StepStatus::Failed(e.to_string()));
+            app.wizard_state.error = Some(format!("Failed to link file: {}", e));
+            app.wizard_state.is_downloading = false;
+            return;
+        }
+    }
+
+    // Repoint game dir symlinks to the new manifest's objects
+    if let Err(e) = rewind_core::cache::repoint_symlinks(&dl.game_install_path, &target_cache) {
+        app.set_step_status(&StepKind::LinkFiles, StepStatus::Failed(e.to_string()));
+        app.wizard_state.error = Some(format!("Failed to link game files: {}", e));
+        app.wizard_state.is_downloading = false;
+        return;
+    }
     app.set_step_status(&StepKind::LinkFiles, StepStatus::Done);
 
     // Update game config

--- a/rewind-cli/src/main.rs
+++ b/rewind-cli/src/main.rs
@@ -1005,6 +1005,12 @@ fn start_download(app: &mut App) {
         acf_path: game.acf_path.clone(),
     });
 
+    let dl_app_id = game.app_id;
+    let dl_depot_id = game.depot_id;
+    let dl_manifest_id = app.pending_download.as_ref().map(|d| d.manifest_id.clone()).unwrap_or_default();
+    let dl_username = username.clone();
+    let dl_cache_dir = cache_dir.clone();
+
     let tx2 = tx.clone();
     tokio::spawn(async move {
         if !rewind_core::depot::check_dotnet().await {
@@ -1046,8 +1052,50 @@ fn start_download(app: &mut App) {
                 "__STEP_START:DownloadManifest".into(),
             ))
             .await;
+
+        // Phase 1: run manifest-only to get per-file SHA1s without downloading
+        if let Err(e) = rewind_core::depot::run_manifest_only(
+            &binary,
+            dl_app_id,
+            dl_depot_id,
+            &dl_manifest_id,
+            &dl_username,
+            &dl_cache_dir,
+        )
+        .await
+        {
+            let _ = tx2
+                .send(rewind_core::depot::DepotProgress::Error(e.to_string()))
+                .await;
+            return;
+        }
+
+        // Parse manifest txt and determine which files are missing from the object store
+        let manifest_txt = dl_cache_dir
+            .join(format!("manifest_{}_{}.txt", dl_depot_id, dl_manifest_id));
+        let entries = rewind_core::cache::parse_manifest_txt(&manifest_txt).unwrap_or_default();
+        let depot_dir = dl_cache_dir
+            .parent()
+            .expect("manifest cache dir has parent depot dir")
+            .to_path_buf();
+        let missing = rewind_core::cache::missing_entries(&depot_dir, &entries);
+
+        let filelist_path = if missing.is_empty() {
+            None
+        } else {
+            let path = dl_cache_dir.join(".filelist");
+            let content = missing.iter().map(|e| e.name.as_str()).collect::<Vec<_>>().join("\n");
+            if let Err(e) = std::fs::write(&path, content) {
+                let _ = tx2
+                    .send(rewind_core::depot::DepotProgress::Error(e.to_string()))
+                    .await;
+                return;
+            }
+            Some(path)
+        };
+
         let _ = tx2
-            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path: None })
+            .send(rewind_core::depot::DepotProgress::ReadyToDownload { binary, filelist_path })
             .await;
     });
 }

--- a/rewind-cli/src/ui/version_picker.rs
+++ b/rewind-cli/src/ui/version_picker.rs
@@ -3,6 +3,8 @@ use crate::ui::theme;
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Margin},
+    style::Modifier,
+    text::{Line, Span},
     widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph},
 };
 
@@ -80,19 +82,36 @@ pub fn draw(f: &mut Frame, app: &App) {
                 let is_latest = manifest_id == latest;
 
                 let user_label = app.manifest_db.get_label(manifest_id);
-                let display = match user_label {
-                    Some(lbl) => format!("{lbl}  {manifest_id}"),
-                    None => manifest_id.clone(),
+
+                let bullet = if is_active { "● " } else { "  " };
+
+                let suffix = match (is_active, is_latest) {
+                    (true, true) => " (installed) (latest)",
+                    (true, false) => " (installed)",
+                    (false, true) => " (latest)",
+                    (false, false) => "",
                 };
 
-                let label = match (is_active, is_latest) {
-                    (true, true) => format!("● {display} (installed) (latest)"),
-                    (true, false) => format!("● {display} (installed)"),
-                    (false, true) => format!("  {display} (latest)"),
-                    (false, false) => format!("  {display}"),
-                };
+                let mut spans: Vec<Span> = vec![Span::raw(bullet)];
+                match user_label {
+                    Some(lbl) => {
+                        spans.push(Span::styled(
+                            lbl.to_string(),
+                            theme::text().add_modifier(Modifier::BOLD),
+                        ));
+                        spans.push(Span::raw("  "));
+                        spans.push(Span::styled(
+                            manifest_id.clone(),
+                            theme::text().add_modifier(Modifier::DIM),
+                        ));
+                    }
+                    None => {
+                        spans.push(Span::raw(manifest_id.clone()));
+                    }
+                }
+                spans.push(Span::raw(suffix));
 
-                let style = if i == app.version_picker_state.selected_index {
+                let row_style = if i == app.version_picker_state.selected_index {
                     theme::selected()
                 } else if is_active {
                     theme::status_success()
@@ -100,7 +119,7 @@ pub fn draw(f: &mut Frame, app: &App) {
                     theme::text()
                 };
 
-                ListItem::new(label).style(style)
+                ListItem::new(Line::from(spans)).style(row_style)
             })
             .collect();
 

--- a/rewind-cli/src/ui/version_picker.rs
+++ b/rewind-cli/src/ui/version_picker.rs
@@ -1,4 +1,4 @@
-use crate::app::App;
+use crate::app::{App, VersionPickerMode};
 use crate::ui::theme;
 use ratatui::{
     Frame,
@@ -24,11 +24,18 @@ pub fn draw(f: &mut Frame, app: &App) {
         || app.version_picker_state.error.is_some();
     let info_height: u16 = if has_info { 1 } else { 0 };
 
+    let editing = matches!(
+        app.version_picker_state.mode,
+        VersionPickerMode::EditingLabel { .. }
+    );
+    let editor_height: u16 = if editing { 1 } else { 0 };
+
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(info_height), // warning / error line
             Constraint::Min(0),              // version list
+            Constraint::Length(editor_height), // inline label editor
             Constraint::Length(1),           // help bar
         ])
         .split(inner.inner(Margin { horizontal: 1, vertical: 0 }));
@@ -71,11 +78,18 @@ pub fn draw(f: &mut Frame, app: &App) {
             .map(|(i, manifest_id)| {
                 let is_active = manifest_id == active;
                 let is_latest = manifest_id == latest;
+
+                let user_label = app.manifest_db.get_label(manifest_id);
+                let display = match user_label {
+                    Some(lbl) => format!("{lbl}  {manifest_id}"),
+                    None => manifest_id.clone(),
+                };
+
                 let label = match (is_active, is_latest) {
-                    (true, true) => format!("● {} (installed) (latest)", manifest_id),
-                    (true, false) => format!("● {} (installed)", manifest_id),
-                    (false, true) => format!("  {} (latest)", manifest_id),
-                    (false, false) => format!("  {}", manifest_id),
+                    (true, true) => format!("● {display} (installed) (latest)"),
+                    (true, false) => format!("● {display} (installed)"),
+                    (false, true) => format!("  {display} (latest)"),
+                    (false, false) => format!("  {display}"),
                 };
 
                 let style = if i == app.version_picker_state.selected_index {
@@ -94,7 +108,17 @@ pub fn draw(f: &mut Frame, app: &App) {
         f.render_widget(list, layout[1]);
     }
 
-    let help = Paragraph::new(" [↑↓] select   [Enter] switch   [Esc] cancel ")
-        .style(theme::help_bar());
-    f.render_widget(help, layout[2]);
+    if let VersionPickerMode::EditingLabel { input } = &app.version_picker_state.mode {
+        let bar = Paragraph::new(format!(" Label: {}█", input))
+            .style(theme::text());
+        f.render_widget(bar, layout[2]);
+    }
+
+    let help_text = if editing {
+        " [Enter] confirm   [Esc] cancel "
+    } else {
+        " [↑↓] select   [Enter] switch   [E] label   [Esc] cancel "
+    };
+    let help = Paragraph::new(help_text).style(theme::help_bar());
+    f.render_widget(help, layout[3]);
 }

--- a/rewind-core/Cargo.toml
+++ b/rewind-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rewind-core"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -133,6 +133,42 @@ pub fn list_cached_manifests(cache_root: &Path, app_id: u32, depot_id: u32) -> V
         .unwrap_or_default()
 }
 
+#[derive(Debug, Clone)]
+pub struct ManifestEntry {
+    pub name: String,
+    pub sha1: String,
+    pub size_bytes: u64,
+}
+
+/// Parse a DepotDownloader manifest txt file (produced by `-manifest-only`) into entries.
+/// Skips the header block. Data rows are whitespace-split: [size, chunks, sha1, flags, name]
+pub fn parse_manifest_txt(path: &Path) -> Result<Vec<ManifestEntry>, CacheError> {
+    let content = std::fs::read_to_string(path)?;
+    let mut entries = Vec::new();
+    let mut in_data = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Size") && trimmed.contains("Chunks") && trimmed.contains("File SHA") {
+            in_data = true;
+            continue;
+        }
+        if !in_data || trimmed.is_empty() {
+            continue;
+        }
+        let parts: Vec<&str> = trimmed.split_whitespace().collect();
+        if parts.len() < 5 {
+            continue;
+        }
+        let size_bytes: u64 = parts[0].parse().unwrap_or(0);
+        let sha1 = parts[2].to_string();
+        let name = parts[4..].join(" ");
+        entries.push(ManifestEntry { name, sha1, size_bytes });
+    }
+
+    Ok(entries)
+}
+
 #[cfg(unix)]
 fn create_symlink(target: &Path, link: &Path) -> Result<(), CacheError> {
     std::os::unix::fs::symlink(target, link)?;
@@ -251,5 +287,52 @@ mod tests {
         assert_eq!(manifests.len(), 2);
         assert!(manifests.contains(&"v1".to_string()));
         assert!(manifests.contains(&"v2".to_string()));
+    }
+
+    #[test]
+    fn parse_manifest_txt_parses_entries() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("manifest.txt");
+        fs::write(&path,
+            "Content Manifest for Depot 3321461\n\
+             \n\
+             Manifest ID / date     : 123 / 01/01/2024 00:00:00\n\
+             Total number of files  : 2\n\
+             Total number of chunks : 5\n\
+             Total bytes on disk    : 1000\n\
+             Total bytes compressed : 800\n\
+             \n\
+             \n\
+                       Size Chunks File SHA                                 Flags Name\n\
+                    100      1 aabbccdd00112233445566778899001122334455     0 dir/file.pak\n\
+                    200      2 ffeeddccbbaa99887766554433221100ffeeddcc     0 other.bin\n"
+        ).unwrap();
+
+        let entries = parse_manifest_txt(&path).unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "dir/file.pak");
+        assert_eq!(entries[0].sha1, "aabbccdd00112233445566778899001122334455");
+        assert_eq!(entries[0].size_bytes, 100);
+        assert_eq!(entries[1].name, "other.bin");
+        assert_eq!(entries[1].sha1, "ffeeddccbbaa99887766554433221100ffeeddcc");
+        assert_eq!(entries[1].size_bytes, 200);
+    }
+
+    #[test]
+    fn parse_manifest_txt_empty_file_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("manifest.txt");
+        fs::write(&path, "").unwrap();
+        let entries = parse_manifest_txt(&path).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_manifest_txt_header_only_returns_empty() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("manifest.txt");
+        fs::write(&path, "Content Manifest for Depot 123\n\nManifest ID: 456\n").unwrap();
+        let entries = parse_manifest_txt(&path).unwrap();
+        assert!(entries.is_empty());
     }
 }

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -169,6 +169,21 @@ pub fn parse_manifest_txt(path: &Path) -> Result<Vec<ManifestEntry>, CacheError>
     Ok(entries)
 }
 
+/// Move `src` into `depot_dir/.objects/<sha1>`.
+/// If the object already exists, the source file is removed (discard the duplicate).
+/// Returns the object path.
+pub fn intern_object(depot_dir: &Path, src: &Path, sha1: &str) -> Result<PathBuf, CacheError> {
+    let objects_dir = depot_dir.join(".objects");
+    std::fs::create_dir_all(&objects_dir)?;
+    let dest = objects_dir.join(sha1);
+    if dest.try_exists().unwrap_or(false) {
+        std::fs::remove_file(src)?;
+    } else {
+        std::fs::rename(src, &dest)?;
+    }
+    Ok(dest)
+}
+
 /// Returns entries whose SHA1 is not present in `depot_dir/.objects/<sha1>`.
 pub fn missing_entries<'a>(
     depot_dir: &Path,
@@ -401,5 +416,45 @@ mod tests {
         let missing = missing_entries(tmp.path(), &entries);
         assert_eq!(missing.len(), 1);
         assert_eq!(missing[0].sha1, "bbbb");
+    }
+
+    #[test]
+    fn intern_object_moves_file_to_objects() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("file.pak");
+        fs::write(&src, b"game content").unwrap();
+        let depot_dir = tmp.path().join("depot");
+
+        let result = intern_object(&depot_dir, &src, "abc123").unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(result, depot_dir.join(".objects/abc123"));
+        assert_eq!(fs::read(&result).unwrap(), b"game content");
+    }
+
+    #[test]
+    fn intern_object_idempotent_when_object_exists() {
+        let tmp = TempDir::new().unwrap();
+        let objects = tmp.path().join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("abc123"), b"existing").unwrap();
+
+        let src = tmp.path().join("dup.pak");
+        fs::write(&src, b"duplicate content").unwrap();
+
+        let result = intern_object(tmp.path(), &src, "abc123").unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(fs::read(&result).unwrap(), b"existing");
+    }
+
+    #[test]
+    fn intern_object_returns_correct_path() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join("x.pak");
+        fs::write(&src, b"x").unwrap();
+
+        let path = intern_object(tmp.path(), &src, "deadbeef").unwrap();
+        assert_eq!(path, tmp.path().join(".objects/deadbeef"));
     }
 }

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -177,7 +177,7 @@ pub fn missing_entries<'a>(
     let objects_dir = depot_dir.join(".objects");
     entries
         .iter()
-        .filter(|e| !objects_dir.join(&e.sha1).exists())
+        .filter(|e| !objects_dir.join(&e.sha1).try_exists().unwrap_or(false))
         .collect()
 }
 

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -93,6 +93,7 @@ pub fn repoint_symlinks(game_dir: &Path, new_cache_dir: &Path) -> Result<(), Cac
 /// Restore original files: remove symlinks in game_dir and replace with files from backup_cache_dir.
 pub fn restore_from_cache(game_dir: &Path, backup_cache_dir: &Path) -> Result<(), CacheError> {
     for entry in WalkDir::new(backup_cache_dir)
+        .follow_links(true)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -70,6 +70,7 @@ pub fn apply_downloaded(
 /// Only repoints files that exist in new_cache_dir.
 pub fn repoint_symlinks(game_dir: &Path, new_cache_dir: &Path) -> Result<(), CacheError> {
     for entry in WalkDir::new(new_cache_dir)
+        .follow_links(true)
         .into_iter()
         .filter_map(|e| e.ok())
         .filter(|e| e.file_type().is_file())
@@ -126,6 +127,7 @@ pub fn list_cached_manifests(cache_root: &Path, app_id: u32, depot_id: u32) -> V
                 .filter_map(|e| e.ok())
                 .filter(|e| e.path().is_dir())
                 .filter_map(|e| e.file_name().into_string().ok())
+                .filter(|name| name != ".objects")
                 .collect();
             manifests.sort();
             manifests
@@ -531,5 +533,47 @@ mod tests {
         link_object(tmp.path(), "v2hash", &manifest_dir, "file.pak").unwrap();
 
         assert_eq!(fs::read(manifest_dir.join("file.pak")).unwrap(), b"v2 content");
+    }
+
+    #[test]
+    fn list_cached_manifests_excludes_objects_dir() {
+        let tmp = TempDir::new().unwrap();
+        let cache_root = tmp.path();
+        let dir1 = manifest_cache_dir(cache_root, 1234, 5678, "v1");
+        fs::create_dir_all(&dir1).unwrap();
+        let objects = cache_root.join("1234/5678/.objects");
+        fs::create_dir_all(&objects).unwrap();
+
+        let manifests = list_cached_manifests(cache_root, 1234, 5678);
+        assert_eq!(manifests, vec!["v1".to_string()]);
+        assert!(!manifests.contains(&".objects".to_string()));
+    }
+
+    #[test]
+    fn repoint_symlinks_follows_symlinks_into_objects() {
+        let tmp = TempDir::new().unwrap();
+        // Set up object store
+        let depot_dir = tmp.path().join("cache/1/2");
+        let objects = depot_dir.join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("sha_v2"), b"v2 content").unwrap();
+
+        // Manifest dir where file is a symlink to .objects
+        let manifest_dir = depot_dir.join("v2");
+        fs::create_dir_all(&manifest_dir).unwrap();
+        let obj_abs = fs::canonicalize(objects.join("sha_v2")).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&obj_abs, manifest_dir.join("main.pak")).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&obj_abs, manifest_dir.join("main.pak")).unwrap();
+
+        // Game dir with an old file
+        let game_dir = tmp.path().join("game");
+        fs::create_dir_all(&game_dir).unwrap();
+        fs::write(game_dir.join("main.pak"), b"old content").unwrap();
+
+        repoint_symlinks(&game_dir, &manifest_dir).unwrap();
+
+        assert_eq!(fs::read(game_dir.join("main.pak")).unwrap(), b"v2 content");
     }
 }

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -184,6 +184,29 @@ pub fn intern_object(depot_dir: &Path, src: &Path, sha1: &str) -> Result<PathBuf
     Ok(dest)
 }
 
+/// Create a symlink at `manifest_dir/<name>` pointing to the absolute path of
+/// `depot_dir/.objects/<sha1>`. Creates parent directories as needed.
+/// Overwrites an existing symlink at the same path.
+pub fn link_object(
+    depot_dir: &Path,
+    sha1: &str,
+    manifest_dir: &Path,
+    name: &str,
+) -> Result<(), CacheError> {
+    let object_path = depot_dir.join(".objects").join(sha1);
+    let target_abs = std::fs::canonicalize(&object_path)?;
+    let link_path = manifest_dir.join(name);
+
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    if link_path.try_exists().unwrap_or(false) || is_symlink(&link_path) {
+        remove_file_or_symlink(&link_path)?;
+    }
+    create_symlink(&target_abs, &link_path)?;
+    Ok(())
+}
+
 /// Returns entries whose SHA1 is not present in `depot_dir/.objects/<sha1>`.
 pub fn missing_entries<'a>(
     depot_dir: &Path,
@@ -456,5 +479,57 @@ mod tests {
 
         let path = intern_object(tmp.path(), &src, "deadbeef").unwrap();
         assert_eq!(path, tmp.path().join(".objects/deadbeef"));
+    }
+
+    #[test]
+    fn link_object_creates_readable_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let objects = tmp.path().join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("abc123"), b"game content").unwrap();
+
+        let manifest_dir = tmp.path().join("manifest_aaa");
+        fs::create_dir_all(&manifest_dir).unwrap();
+
+        link_object(tmp.path(), "abc123", &manifest_dir, "file.pak").unwrap();
+
+        let link = manifest_dir.join("file.pak");
+        #[cfg(unix)]
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read(&link).unwrap(), b"game content");
+    }
+
+    #[test]
+    fn link_object_creates_subdirectories() {
+        let tmp = TempDir::new().unwrap();
+        let objects = tmp.path().join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("deadbeef"), b"chunk data").unwrap();
+
+        let manifest_dir = tmp.path().join("manifest_bbb");
+        fs::create_dir_all(&manifest_dir).unwrap();
+
+        link_object(tmp.path(), "deadbeef", &manifest_dir, "0000/0.paz").unwrap();
+
+        let link = manifest_dir.join("0000/0.paz");
+        assert!(link.exists());
+        assert_eq!(fs::read(&link).unwrap(), b"chunk data");
+    }
+
+    #[test]
+    fn link_object_overwrites_existing_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let objects = tmp.path().join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("v1hash"), b"v1 content").unwrap();
+        fs::write(objects.join("v2hash"), b"v2 content").unwrap();
+
+        let manifest_dir = tmp.path().join("manifest");
+        fs::create_dir_all(&manifest_dir).unwrap();
+
+        link_object(tmp.path(), "v1hash", &manifest_dir, "file.pak").unwrap();
+        link_object(tmp.path(), "v2hash", &manifest_dir, "file.pak").unwrap();
+
+        assert_eq!(fs::read(manifest_dir.join("file.pak")).unwrap(), b"v2 content");
     }
 }

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -169,6 +169,18 @@ pub fn parse_manifest_txt(path: &Path) -> Result<Vec<ManifestEntry>, CacheError>
     Ok(entries)
 }
 
+/// Returns entries whose SHA1 is not present in `depot_dir/.objects/<sha1>`.
+pub fn missing_entries<'a>(
+    depot_dir: &Path,
+    entries: &'a [ManifestEntry],
+) -> Vec<&'a ManifestEntry> {
+    let objects_dir = depot_dir.join(".objects");
+    entries
+        .iter()
+        .filter(|e| !objects_dir.join(&e.sha1).exists())
+        .collect()
+}
+
 #[cfg(unix)]
 fn create_symlink(target: &Path, link: &Path) -> Result<(), CacheError> {
     std::os::unix::fs::symlink(target, link)?;
@@ -348,5 +360,46 @@ mod tests {
         let entries = parse_manifest_txt(&path).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].name, "Data Files/main.pak");
+    }
+
+    #[test]
+    fn missing_entries_all_missing() {
+        let tmp = TempDir::new().unwrap();
+        let entries = vec![
+            ManifestEntry { name: "a.pak".into(), sha1: "aaaa".into(), size_bytes: 10 },
+            ManifestEntry { name: "b.pak".into(), sha1: "bbbb".into(), size_bytes: 20 },
+        ];
+        let missing = missing_entries(tmp.path(), &entries);
+        assert_eq!(missing.len(), 2);
+    }
+
+    #[test]
+    fn missing_entries_all_present() {
+        let tmp = TempDir::new().unwrap();
+        let objects = tmp.path().join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("aaaa"), b"content a").unwrap();
+        fs::write(objects.join("bbbb"), b"content b").unwrap();
+        let entries = vec![
+            ManifestEntry { name: "a.pak".into(), sha1: "aaaa".into(), size_bytes: 10 },
+            ManifestEntry { name: "b.pak".into(), sha1: "bbbb".into(), size_bytes: 20 },
+        ];
+        let missing = missing_entries(tmp.path(), &entries);
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn missing_entries_mixed() {
+        let tmp = TempDir::new().unwrap();
+        let objects = tmp.path().join(".objects");
+        fs::create_dir_all(&objects).unwrap();
+        fs::write(objects.join("aaaa"), b"content a").unwrap();
+        let entries = vec![
+            ManifestEntry { name: "a.pak".into(), sha1: "aaaa".into(), size_bytes: 10 },
+            ManifestEntry { name: "b.pak".into(), sha1: "bbbb".into(), size_bytes: 20 },
+        ];
+        let missing = missing_entries(tmp.path(), &entries);
+        assert_eq!(missing.len(), 1);
+        assert_eq!(missing[0].sha1, "bbbb");
     }
 }

--- a/rewind-core/src/cache.rs
+++ b/rewind-core/src/cache.rs
@@ -133,7 +133,7 @@ pub fn list_cached_manifests(cache_root: &Path, app_id: u32, depot_id: u32) -> V
         .unwrap_or_default()
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ManifestEntry {
     pub name: String,
     pub sha1: String,
@@ -160,7 +160,7 @@ pub fn parse_manifest_txt(path: &Path) -> Result<Vec<ManifestEntry>, CacheError>
         if parts.len() < 5 {
             continue;
         }
-        let size_bytes: u64 = parts[0].parse().unwrap_or(0);
+        let Ok(size_bytes) = parts[0].parse::<u64>() else { continue };
         let sha1 = parts[2].to_string();
         let name = parts[4..].join(" ");
         entries.push(ManifestEntry { name, sha1, size_bytes });
@@ -334,5 +334,19 @@ mod tests {
         fs::write(&path, "Content Manifest for Depot 123\n\nManifest ID: 456\n").unwrap();
         let entries = parse_manifest_txt(&path).unwrap();
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn parse_manifest_txt_handles_name_with_spaces() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("manifest.txt");
+        fs::write(&path,
+            "          Size Chunks File SHA                                 Flags Name\n\
+                    100      1 aabbccdd00112233445566778899001122334455     0 Data Files/main.pak\n"
+        ).unwrap();
+
+        let entries = parse_manifest_txt(&path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "Data Files/main.pak");
     }
 }

--- a/rewind-core/src/depot.rs
+++ b/rewind-core/src/depot.rs
@@ -27,8 +27,10 @@ pub enum DepotError {
 pub enum DepotProgress {
     /// A status/info line to display while preparing the download.
     Line(String),
-    /// DepotDownloader binary is ready at this path; interactive download can start.
-    ReadyToDownload { binary: std::path::PathBuf },
+    /// DepotDownloader binary is ready; interactive download can start.
+    /// `filelist_path` is Some when only missing files need downloading (deduplication).
+    /// If None, all files are already cached and the download should be skipped.
+    ReadyToDownload { binary: std::path::PathBuf, filelist_path: Option<std::path::PathBuf> },
     /// DepotDownloader is waiting for user input (e.g. password, Steam Guard).
     Prompt(String),
     Done,
@@ -78,6 +80,22 @@ pub fn build_args(
         "-dir".into(),
         output_dir.to_string(),
     ]
+}
+
+/// Build args for a targeted download using a filelist.
+/// Used when only a subset of manifest files need to be downloaded (deduplication).
+pub fn build_filelist_args(
+    app_id: u32,
+    depot_id: u32,
+    manifest_id: &str,
+    username: &str,
+    output_dir: &str,
+    filelist_path: &str,
+) -> Vec<String> {
+    let mut args = build_args(app_id, depot_id, manifest_id, username, output_dir);
+    args.push("-filelist".into());
+    args.push(filelist_path.into());
+    args
 }
 
 /// Returns the path to the DepotDownloader binary in the rewind bin dir.
@@ -291,6 +309,48 @@ pub async fn run_depot_downloader_interactive(
     }
 }
 
+/// Run DepotDownloader with `-manifest-only` to produce a human-readable manifest file.
+/// No game files are downloaded. The manifest txt is written to `cache_dir`.
+pub async fn run_manifest_only(
+    binary: &Path,
+    app_id: u32,
+    depot_id: u32,
+    manifest_id: &str,
+    username: &str,
+    cache_dir: &Path,
+) -> Result<(), DepotError> {
+    std::fs::create_dir_all(cache_dir)?;
+    let mut args = build_args(
+        app_id,
+        depot_id,
+        manifest_id,
+        username,
+        cache_dir.to_string_lossy().as_ref(),
+    );
+    args.push("-manifest-only".into());
+
+    let mut cmd = Command::new(binary);
+    cmd.args(&args)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    #[cfg(unix)]
+    unsafe {
+        cmd.pre_exec(|| {
+            libc::setsid();
+            Ok(())
+        });
+    }
+
+    let status = cmd.spawn()?.wait().await?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(DepotError::ExitFailure(status.code().unwrap_or(-1)))
+    }
+}
+
 /// Run DepotDownloader with piped stdin/stdout/stderr.
 /// Returns a ChildStdin handle so the caller can forward credential input,
 /// and a kill sender that can be used to terminate the child process.
@@ -302,17 +362,28 @@ pub async fn run_depot_downloader(
     manifest_id: &str,
     username: &str,
     cache_dir: &Path,
+    filelist_path: Option<&Path>,
     tx: mpsc::Sender<DepotProgress>,
 ) -> Result<(tokio::process::ChildStdin, mpsc::Sender<()>), DepotError> {
     std::fs::create_dir_all(cache_dir)?;
 
-    let args = build_args(
-        app_id,
-        depot_id,
-        manifest_id,
-        username,
-        cache_dir.to_string_lossy().as_ref(),
-    );
+    let args = match filelist_path {
+        Some(fp) => build_filelist_args(
+            app_id,
+            depot_id,
+            manifest_id,
+            username,
+            cache_dir.to_string_lossy().as_ref(),
+            fp.to_string_lossy().as_ref(),
+        ),
+        None => build_args(
+            app_id,
+            depot_id,
+            manifest_id,
+            username,
+            cache_dir.to_string_lossy().as_ref(),
+        ),
+    };
 
     let mut cmd = Command::new(binary);
     cmd.args(&args)
@@ -413,5 +484,16 @@ mod tests {
         assert!(path.ends_with("DepotDownloader"));
         #[cfg(target_os = "windows")]
         assert!(path.ends_with("DepotDownloader.exe"));
+    }
+
+    #[test]
+    fn build_filelist_args_includes_filelist_flag() {
+        let args = build_filelist_args(570, 571, "abc123", "user", "/tmp/out", "/tmp/list.txt");
+        let s: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        assert!(s.contains(&"-filelist"));
+        let idx = s.iter().position(|&x| x == "-filelist").unwrap();
+        assert_eq!(s[idx + 1], "/tmp/list.txt");
+        assert!(s.contains(&"-app"));
+        assert!(s.contains(&"-manifest"));
     }
 }

--- a/rewind-core/src/lib.rs
+++ b/rewind-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod depot;
 pub mod image_cache;
 pub mod immutability;
+pub mod manifest_db;
 pub mod patcher;
 pub mod reshade;
 pub mod scanner;

--- a/rewind-core/src/manifest_db.rs
+++ b/rewind-core/src/manifest_db.rs
@@ -1,0 +1,102 @@
+use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use crate::config::ConfigError;
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ManifestDb {
+    #[serde(default)]
+    pub manifests: HashMap<String, ManifestMeta>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
+pub struct ManifestMeta {
+    pub label: Option<String>,
+}
+
+impl ManifestDb {
+    pub fn get_label(&self, manifest_id: &str) -> Option<&str> {
+        self.manifests.get(manifest_id)?.label.as_deref()
+    }
+
+    pub fn set_label(&mut self, manifest_id: &str, label: String) {
+        self.manifests
+            .entry(manifest_id.to_string())
+            .or_default()
+            .label = Some(label);
+    }
+
+    pub fn clear_label(&mut self, manifest_id: &str) {
+        if let Some(meta) = self.manifests.get_mut(manifest_id) {
+            meta.label = None;
+        }
+    }
+}
+
+pub fn load_manifest_db() -> Result<ManifestDb, ConfigError> {
+    let path = crate::config::data_dir()?.join("manifests.toml");
+    if !path.exists() {
+        return Ok(ManifestDb::default());
+    }
+    let content = std::fs::read_to_string(&path)?;
+    Ok(toml::from_str(&content)?)
+}
+
+pub fn save_manifest_db(db: &ManifestDb) -> Result<(), ConfigError> {
+    let path = crate::config::data_dir()?.join("manifests.toml");
+    let content = toml::to_string_pretty(db)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_label_returns_none_when_no_entry() {
+        let db = ManifestDb::default();
+        assert!(db.get_label("12345").is_none());
+    }
+
+    #[test]
+    fn set_and_get_label_roundtrip() {
+        let mut db = ManifestDb::default();
+        db.set_label("12345", "pre-nerf".to_string());
+        assert_eq!(db.get_label("12345"), Some("pre-nerf"));
+    }
+
+    #[test]
+    fn clear_label_removes_it() {
+        let mut db = ManifestDb::default();
+        db.set_label("12345", "pre-nerf".to_string());
+        db.clear_label("12345");
+        assert!(db.get_label("12345").is_none());
+    }
+
+    #[test]
+    fn clear_label_on_missing_entry_is_noop() {
+        let mut db = ManifestDb::default();
+        db.clear_label("nonexistent"); // must not panic
+    }
+
+    #[test]
+    fn toml_roundtrip_preserves_labels() {
+        let mut db = ManifestDb::default();
+        db.set_label("7291048563840537431", "pre-nerf".to_string());
+        db.set_label("8812034512345678901", "1.04".to_string());
+
+        let serialized = toml::to_string_pretty(&db).unwrap();
+        let parsed: ManifestDb = toml::from_str(&serialized).unwrap();
+
+        assert_eq!(parsed.get_label("7291048563840537431"), Some("pre-nerf"));
+        assert_eq!(parsed.get_label("8812034512345678901"), Some("1.04"));
+    }
+
+    #[test]
+    fn missing_file_returns_default() {
+        // load_manifest_db uses data_dir() which we can't easily redirect in tests,
+        // but we can verify that an empty TOML string deserializes to default.
+        let db: ManifestDb = toml::from_str("").unwrap();
+        assert!(db.manifests.is_empty());
+    }
+}

--- a/rewind-core/tests/integration.rs
+++ b/rewind-core/tests/integration.rs
@@ -1,5 +1,8 @@
 // rewind-core/tests/integration.rs
-use rewind_core::{cache, immutability, patcher};
+use rewind_core::{
+    cache::{self, intern_object, link_object, missing_entries, ManifestEntry},
+    immutability, patcher,
+};
 use std::fs;
 use tempfile::TempDir;
 
@@ -73,6 +76,155 @@ fn full_downgrade_and_switch_flow() {
             !meta.file_type().is_symlink(),
             "file should be real after restore"
         );
+    }
+}
+
+// Helper: build a ManifestEntry for tests.
+fn entry(name: &str, sha1: &str) -> ManifestEntry {
+    ManifestEntry { name: name.to_string(), sha1: sha1.to_string(), size_bytes: 4 }
+}
+
+/// Scenario: all files missing from .objects/ → every entry must be interned + linked.
+#[test]
+fn dedup_all_files_missing() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let depot_dir = tmp.path().join("depot");
+    let manifest_dir = tmp.path().join("manifest");
+    fs::create_dir_all(&manifest_dir).unwrap();
+
+    let entries = vec![
+        entry("a.pak", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        entry("b.pak", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+    ];
+
+    // Nothing in .objects/ yet — all are missing.
+    let missing = missing_entries(&depot_dir, &entries);
+    assert_eq!(missing.len(), 2);
+
+    // Simulate download: place files in manifest_dir as DepotDownloader would.
+    fs::write(manifest_dir.join("a.pak"), b"aaa content").unwrap();
+    fs::write(manifest_dir.join("b.pak"), b"bbb content").unwrap();
+
+    // Intern + link each file.
+    for e in &entries {
+        let src = manifest_dir.join(&e.name);
+        intern_object(&depot_dir, &src, &e.sha1).unwrap();
+        link_object(&depot_dir, &e.sha1, &manifest_dir, &e.name).unwrap();
+    }
+
+    // Objects exist.
+    assert!(depot_dir.join(".objects").join(&entries[0].sha1).exists());
+    assert!(depot_dir.join(".objects").join(&entries[1].sha1).exists());
+
+    // Symlinks in manifest_dir resolve to correct content.
+    assert_eq!(fs::read(manifest_dir.join("a.pak")).unwrap(), b"aaa content");
+    assert_eq!(fs::read(manifest_dir.join("b.pak")).unwrap(), b"bbb content");
+
+    // All present now — nothing missing.
+    let missing_after = missing_entries(&depot_dir, &entries);
+    assert!(missing_after.is_empty());
+}
+
+/// Scenario: all files already present in .objects/ → nothing to download, only link.
+#[test]
+fn dedup_all_files_present() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let depot_dir = tmp.path().join("depot");
+    let manifest_dir = tmp.path().join("manifest");
+    fs::create_dir_all(&manifest_dir).unwrap();
+
+    let entries = vec![entry("0000/0.paz", "cccccccccccccccccccccccccccccccccccccccc")];
+
+    // Pre-populate .objects/ as if a prior manifest had already downloaded this file.
+    let objects_dir = depot_dir.join(".objects");
+    fs::create_dir_all(&objects_dir).unwrap();
+    fs::write(objects_dir.join(&entries[0].sha1), b"shared content").unwrap();
+
+    // Nothing missing — skip download entirely.
+    let missing = missing_entries(&depot_dir, &entries);
+    assert!(missing.is_empty());
+
+    // Still create symlinks.
+    for e in &entries {
+        link_object(&depot_dir, &e.sha1, &manifest_dir, &e.name).unwrap();
+    }
+
+    // Symlink resolves correctly without any download.
+    assert_eq!(
+        fs::read(manifest_dir.join("0000/0.paz")).unwrap(),
+        b"shared content"
+    );
+}
+
+/// Scenario: partial overlap — only missing files downloaded + interned, all linked.
+#[test]
+fn dedup_partial_overlap() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let depot_dir = tmp.path().join("depot");
+    let manifest_dir = tmp.path().join("manifest");
+    fs::create_dir_all(&manifest_dir).unwrap();
+
+    let entries = vec![
+        entry("old.pak", "dddddddddddddddddddddddddddddddddddddddd"), // already cached
+        entry("new.pak", "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"), // needs download
+    ];
+
+    // Pre-populate only the first object.
+    let objects_dir = depot_dir.join(".objects");
+    fs::create_dir_all(&objects_dir).unwrap();
+    fs::write(objects_dir.join(&entries[0].sha1), b"old content").unwrap();
+
+    // Only new.pak is missing.
+    let missing = missing_entries(&depot_dir, &entries);
+    assert_eq!(missing.len(), 1);
+    assert_eq!(missing[0].sha1, entries[1].sha1);
+
+    // Simulate downloading only new.pak.
+    fs::write(manifest_dir.join("new.pak"), b"new content").unwrap();
+    intern_object(&depot_dir, &manifest_dir.join("new.pak"), &entries[1].sha1).unwrap();
+
+    // Link all entries (both cached and newly downloaded).
+    for e in &entries {
+        link_object(&depot_dir, &e.sha1, &manifest_dir, &e.name).unwrap();
+    }
+
+    assert_eq!(fs::read(manifest_dir.join("old.pak")).unwrap(), b"old content");
+    assert_eq!(fs::read(manifest_dir.join("new.pak")).unwrap(), b"new content");
+    assert!(missing_entries(&depot_dir, &entries).is_empty());
+}
+
+/// Regression: restore_from_cache correctly copies content through a symlink chain
+/// (manifest_dir symlink → .objects/ real file).
+#[test]
+fn restore_from_cache_follows_symlink_chain() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let depot_dir = tmp.path().join("depot");
+    let manifest_dir = tmp.path().join("manifest");
+    let game_dir = tmp.path().join("game");
+    fs::create_dir_all(&game_dir).unwrap();
+
+    let e = entry("main.pak", "ffffffffffffffffffffffffffffffffffffffff");
+
+    // Intern the object.
+    let objects_dir = depot_dir.join(".objects");
+    fs::create_dir_all(&objects_dir).unwrap();
+    fs::write(objects_dir.join(&e.sha1), b"v1 content").unwrap();
+
+    // Link into manifest_dir.
+    link_object(&depot_dir, &e.sha1, &manifest_dir, &e.name).unwrap();
+
+    // Repoint game_dir to use the symlinks in manifest_dir.
+    cache::repoint_symlinks(&game_dir, &manifest_dir).unwrap();
+    assert_eq!(fs::read(game_dir.join("main.pak")).unwrap(), b"v1 content");
+
+    // restore_from_cache must copy actual bytes, not a dangling symlink.
+    cache::restore_from_cache(&game_dir, &manifest_dir).unwrap();
+    assert_eq!(fs::read(game_dir.join("main.pak")).unwrap(), b"v1 content");
+
+    #[cfg(unix)]
+    {
+        let meta = game_dir.join("main.pak").symlink_metadata().unwrap();
+        assert!(!meta.file_type().is_symlink(), "restored file must not be a symlink");
     }
 }
 


### PR DESCRIPTION
## What's Changed

- **Content-addressed cache deduplication** — identical files shared across cached versions are stored once on disk; files already cached in another version are never re-downloaded (Closes #46)
- **Version labels** — attach short labels to cached manifest IDs via `E` in the version picker; labels persist in `manifests.toml` (Closes #32)

## Checklist

- [ ] Merge into `main`
- [ ] Merge into `next`
- [ ] Tag `main` with `v0.7.0`